### PR TITLE
feat: add pillbox medication reminder notifications

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -17,6 +17,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
@@ -30,6 +31,10 @@ android {
             signingConfig signingConfigs.debug
         }
     }
+}
+
+dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
 }
 
 flutter {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
     <application
         android:label="corevia_mobile"
         android:name="${applicationName}"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
     <application
         android:label="corevia_mobile"

--- a/lib/core/notification/pillbox_notification.dart
+++ b/lib/core/notification/pillbox_notification.dart
@@ -120,11 +120,16 @@ void _onBackgroundResponse(NotificationResponse details) async {
       headers['Host'] = hostHeader;
     }
 
-    await http.post(
+    final response = await http.post(
       Uri.parse('$baseUrl$route'),
       headers: headers,
       body: jsonEncode({}),
     );
+
+    if (kDebugMode) {
+      debugPrint(
+          '[PillboxNotif] Background API: ${response.statusCode} $route');
+    }
 
     final notifId = payload.hashCode & 0x7FFFFFFF;
     await FlutterLocalNotificationsPlugin().cancel(notifId);
@@ -146,12 +151,12 @@ Future<void> schedulePillboxReminders(List<Intake> intakes) async {
   }
   if (!_initialized) return;
 
-  // Cancel all existing timers and notifications
-  for (final timer in _activeTimers.values) {
-    timer.cancel();
+  // Cancel all existing pillbox timers and their notifications
+  for (final entry in _activeTimers.entries) {
+    entry.value.cancel();
+    await _plugin.cancel(entry.key);
   }
   _activeTimers.clear();
-  await _plugin.cancelAll();
 
   for (final intake in intakes) {
     if (intake.status != 'PENDING') continue;

--- a/lib/core/notification/pillbox_notification.dart
+++ b/lib/core/notification/pillbox_notification.dart
@@ -1,0 +1,257 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:ui';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:http/http.dart' as http;
+import '../../features/pillbox/domain/entities/intake.dart';
+
+const _channelId = 'pillbox_channel';
+const _channelName = 'Rappels médicaments';
+const _channelDesc = 'Rappels pour prendre vos médicaments';
+
+final _plugin = FlutterLocalNotificationsPlugin();
+bool _initialized = false;
+final Map<int, Timer> _activeTimers = {};
+
+// ── Foreground callbacks (set from main.dart) ─────────────────────────────────
+
+void Function(String intakeId, String action)? _foregroundActionHandler;
+void Function()? _onTapHandler;
+
+/// Call from main.dart before [initializePillboxNotifications] to wire up
+/// foreground action handling (provider access) and tap navigation.
+void setPillboxNotificationHandlers({
+  required void Function(String intakeId, String action) onAction,
+  required void Function() onTap,
+}) {
+  _foregroundActionHandler = onAction;
+  _onTapHandler = onTap;
+}
+
+// ── Initialization ────────────────────────────────────────────────────────────
+
+Future<void> initializePillboxNotifications() async {
+  if (_initialized) return;
+
+  const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+  const settings = InitializationSettings(android: android);
+
+  await _plugin.initialize(
+    settings,
+    onDidReceiveNotificationResponse: _onForegroundResponse,
+    onDidReceiveBackgroundNotificationResponse: _onBackgroundResponse,
+  );
+
+  // Request permissions on Android 13+
+  final androidImpl = _plugin.resolvePlatformSpecificImplementation<
+      AndroidFlutterLocalNotificationsPlugin>();
+  await androidImpl?.requestNotificationsPermission();
+
+  _initialized = true;
+}
+
+// ── Foreground response handler ───────────────────────────────────────────────
+
+void _onForegroundResponse(NotificationResponse details) {
+  final payload = details.payload;
+  final actionId = details.actionId;
+
+  if (kDebugMode) {
+    debugPrint(
+        '[PillboxNotif] Foreground: action=$actionId payload=$payload');
+  }
+
+  if (actionId != null &&
+      actionId.isNotEmpty &&
+      payload != null &&
+      payload.isNotEmpty) {
+    _foregroundActionHandler?.call(payload, actionId);
+    final notifId = payload.hashCode & 0x7FFFFFFF;
+    _plugin.cancel(notifId);
+  } else {
+    _onTapHandler?.call();
+  }
+}
+
+// ── Background response handler ───────────────────────────────────────────────
+
+@pragma('vm:entry-point')
+void _onBackgroundResponse(NotificationResponse details) async {
+  final payload = details.payload;
+  final actionId = details.actionId;
+
+  if (actionId == null ||
+      actionId.isEmpty ||
+      payload == null ||
+      payload.isEmpty) {
+    return;
+  }
+
+  try {
+    await dotenv.load(fileName: '.env');
+
+    final baseUrl = dotenv.env['API_BASE_URL_ANDROID'] ??
+        dotenv.env['API_BASE_URL'] ??
+        'https://api.corevia.local';
+    final hostHeader = dotenv.env['API_HOST_HEADER_ANDROID'] ??
+        dotenv.env['API_HOST_HEADER'];
+
+    const storage = FlutterSecureStorage();
+    final token = await storage.read(key: 'auth_token') ?? '';
+
+    final String route;
+    if (actionId == 'taken') {
+      route = '/api/pillbox/intakes/$payload/taken';
+    } else if (actionId == 'skipped') {
+      route = '/api/pillbox/intakes/$payload/skipped';
+    } else {
+      return;
+    }
+
+    final headers = <String, String>{
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer $token',
+      'Origin': baseUrl,
+    };
+    if (hostHeader != null && hostHeader.isNotEmpty) {
+      headers['Host'] = hostHeader;
+    }
+
+    await http.post(
+      Uri.parse('$baseUrl$route'),
+      headers: headers,
+      body: jsonEncode({}),
+    );
+
+    final notifId = payload.hashCode & 0x7FFFFFFF;
+    await FlutterLocalNotificationsPlugin().cancel(notifId);
+  } catch (e) {
+    if (kDebugMode) {
+      debugPrint('[PillboxNotif] Background handler error: $e');
+    }
+  }
+}
+
+// ── Schedule / cancel helpers ─────────────────────────────────────────────────
+
+/// Cancels all pillbox notifications then reschedules every PENDING intake.
+Future<void> schedulePillboxReminders(List<Intake> intakes) async {
+  if (kDebugMode) {
+    final pending = intakes.where((i) => i.status == 'PENDING').length;
+    debugPrint(
+        '[PillboxNotif] schedulePillboxReminders: ${intakes.length} intakes, $pending PENDING, initialized=$_initialized');
+  }
+  if (!_initialized) return;
+
+  // Cancel all existing timers and notifications
+  for (final timer in _activeTimers.values) {
+    timer.cancel();
+  }
+  _activeTimers.clear();
+  await _plugin.cancelAll();
+
+  for (final intake in intakes) {
+    if (intake.status != 'PENDING') continue;
+    _scheduleIntakeReminder(intake);
+  }
+}
+
+void _scheduleIntakeReminder(Intake intake) {
+  final parts = intake.scheduledTime.split(':');
+  if (parts.length < 2) return;
+
+  final hour = int.tryParse(parts[0]);
+  final minute = int.tryParse(parts[1]);
+  if (hour == null || minute == null) return;
+
+  final now = DateTime.now();
+  var scheduled = DateTime(now.year, now.month, now.day, hour, minute);
+  if (scheduled.isBefore(now)) {
+    scheduled = scheduled.add(const Duration(days: 1));
+  }
+
+  final delay = scheduled.difference(now);
+  final dosage =
+      intake.dosageLabel != null ? ' — ${intake.dosageLabel}' : '';
+  final notifId = intake.id.hashCode & 0x7FFFFFFF;
+
+  const actions = [
+    AndroidNotificationAction(
+      'taken',
+      '✅ Pris',
+      showsUserInterface: true,
+      cancelNotification: true,
+    ),
+    AndroidNotificationAction(
+      'skipped',
+      '❌ Ignorer',
+      showsUserInterface: true,
+      cancelNotification: true,
+    ),
+  ];
+
+  final title = '💊 ${intake.medicationName}';
+  final body = 'Il est ${intake.scheduledTime} — c\'est l\'heure de votre prise$dosage';
+
+  final androidDetails = AndroidNotificationDetails(
+    _channelId,
+    _channelName,
+    channelDescription: _channelDesc,
+    importance: Importance.high,
+    priority: Priority.high,
+    actions: actions,
+    color: const Color(0xFF34C759),
+    category: AndroidNotificationCategory.reminder,
+    styleInformation: BigTextStyleInformation(
+      body,
+      contentTitle: title,
+      summaryText: 'Rappel médicament',
+    ),
+    enableVibration: true,
+    vibrationPattern: Int64List.fromList([0, 400, 200, 400]),
+    autoCancel: false,
+    ongoing: false,
+    visibility: NotificationVisibility.public,
+    subText: 'CoreVia',
+  );
+
+  // Use Timer + show() for reliable delivery
+  final timer = Timer(delay, () {
+    _plugin.show(
+      notifId,
+      title,
+      body,
+      NotificationDetails(android: androidDetails),
+      payload: intake.id,
+    );
+    if (kDebugMode) {
+      debugPrint(
+          '[PillboxNotif] FIRED #$notifId "${intake.medicationName}" at ${intake.scheduledTime}');
+    }
+    _activeTimers.remove(notifId);
+  });
+
+  _activeTimers[notifId] = timer;
+
+  if (kDebugMode) {
+    debugPrint(
+        '[PillboxNotif] Scheduled #$notifId "${intake.medicationName}" in ${delay.inMinutes}m${delay.inSeconds % 60}s (at ${intake.scheduledTime})');
+  }
+}
+
+/// Cancels the reminder for a single intake (taken or skipped).
+Future<void> cancelPillboxReminder(String intakeId) async {
+  if (!_initialized) return;
+  final notifId = intakeId.hashCode & 0x7FFFFFFF;
+
+  _activeTimers[notifId]?.cancel();
+  _activeTimers.remove(notifId);
+  await _plugin.cancel(notifId);
+
+  if (kDebugMode) {
+    debugPrint('[PillboxNotif] Cancelled #$notifId (intake $intakeId)');
+  }
+}

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -17,7 +17,7 @@ class HomeScreen extends StatefulWidget {
   State<HomeScreen> createState() => _HomeScreenState();
 }
 
-class _HomeScreenState extends State<HomeScreen> {
+class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   DateTime selectedDate = DateTime.now();
   Map<String, dynamic>? _user;
 
@@ -27,6 +27,7 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _loadUser();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       final provider = context.read<PillboxProvider>();
@@ -35,6 +36,21 @@ class _HomeScreenState extends State<HomeScreen> {
       // Load intakes for the whole week so calendar badges are accurate
       _loadWeekIntakes(provider);
     });
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      // Refresh intakes when the app comes back to foreground
+      // (e.g. after tapping a notification action)
+      context.read<PillboxProvider>().loadTodayIntakes();
+    }
   }
 
   Future<void> _loadUser() async {

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -46,9 +46,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.resumed) {
-      // Refresh intakes when the app comes back to foreground
-      // (e.g. after tapping a notification action)
+    if (state == AppLifecycleState.resumed && mounted) {
       context.read<PillboxProvider>().loadTodayIntakes();
     }
   }

--- a/lib/features/pillbox/presentation/providers/pillbox_provider.dart
+++ b/lib/features/pillbox/presentation/providers/pillbox_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import '../../../../core/notification/pillbox_notification.dart';
 import '../../domain/entities/intake.dart';
 import '../../domain/entities/patient_medication.dart';
 import '../../domain/entities/today_intakes.dart';
@@ -49,6 +50,8 @@ class PillboxProvider with ChangeNotifier {
 
     try {
       _todayIntakes = await _repository.getTodayIntakes();
+      // Schedule notifications for all PENDING intakes
+      schedulePillboxReminders(_todayIntakes?.intakes ?? []);
     } catch (e) {
       _error = 'Erreur lors du chargement du pilulier du jour';
       if (kDebugMode) debugPrint('Pillbox loadTodayIntakes error: $e');
@@ -114,6 +117,7 @@ class PillboxProvider with ChangeNotifier {
     try {
       await _repository.markIntakeTaken(intakeId, notes: notes);
       _updateLocalIntakeStatus(intakeId, status: 'TAKEN');
+      cancelPillboxReminder(intakeId);
     } catch (e) {
       _error = 'Impossible de marquer la prise comme effectuée';
       if (kDebugMode) debugPrint('Pillbox markIntakeTaken error: $e');
@@ -130,6 +134,7 @@ class PillboxProvider with ChangeNotifier {
     try {
       await _repository.markIntakeSkipped(intakeId, notes: notes);
       _updateLocalIntakeStatus(intakeId, status: 'SKIPPED');
+      cancelPillboxReminder(intakeId);
     } catch (e) {
       _error = 'Impossible de marquer la prise comme ignorée';
       if (kDebugMode) debugPrint('Pillbox markIntakeSkipped error: $e');
@@ -150,6 +155,7 @@ class PillboxProvider with ChangeNotifier {
       // Rafraichir les intakes du jour pour afficher le nouveau medicament
       try {
         _todayIntakes = await _repository.getTodayIntakes();
+        schedulePillboxReminders(_todayIntakes?.intakes ?? []);
       } catch (_) {}
     } catch (e) {
       _error = 'Impossible de créer le médicament';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
+import 'package:timezone/data/latest_all.dart' as tz_data;
+import 'package:timezone/timezone.dart' as tz;
 import 'package:provider/provider.dart';
+import 'core/notification/pillbox_notification.dart';
 import 'core/routes/app_router.dart';
 import 'shared/theme/app_theme.dart';
 import 'features/home/presentation/providers/home_provider.dart';
@@ -21,6 +25,11 @@ void main() async {
 
   // Chargez le fichier .env
   await dotenv.load(fileName: ".env");
+
+  // Initialize timezones and set device local timezone
+  tz_data.initializeTimeZones();
+  final tzName = await FlutterTimezone.getLocalTimezone();
+  tz.setLocalLocation(tz.getLocation(tzName));
 
   // Onboarding
   final prefs = await SharedPreferences.getInstance();
@@ -64,18 +73,37 @@ void main() async {
     }
   }
 
+  // Create provider & router before notification init so handlers can use them
+  final pillboxProvider = PillboxProvider(PillboxRepositoryImpl());
+  final router = createRouter(onboardingNotifier, authNotifier);
+
+  // Wire interactive notification actions
+  setPillboxNotificationHandlers(
+    onAction: (intakeId, action) async {
+      if (action == 'taken') {
+        await pillboxProvider.markIntakeTaken(intakeId);
+      } else if (action == 'skipped') {
+        await pillboxProvider.markIntakeSkipped(intakeId);
+      }
+      await pillboxProvider.loadTodayIntakes();
+    },
+    onTap: () {
+      router.go('/home');
+    },
+  );
+  await initializePillboxNotifications();
+
   runApp(
     MultiProvider(
       providers: [
         ChangeNotifierProvider(
-          create: (context) => HomeProvider(HomeRepositoryImpl()),
+          create: (_) => HomeProvider(HomeRepositoryImpl()),
+        ),
+        ChangeNotifierProvider<PillboxProvider>.value(
+          value: pillboxProvider,
         ),
         ChangeNotifierProvider(
-          create: (context) => PillboxProvider(PillboxRepositoryImpl()),
-        ),
-        ChangeNotifierProvider(
-          create: (context) =>
-              MedicationSearchProvider(PillboxRepositoryImpl()),
+          create: (_) => MedicationSearchProvider(PillboxRepositoryImpl()),
         ),
         ChangeNotifierProvider<OnboardingNotifier>.value(
           value: onboardingNotifier,
@@ -84,24 +112,15 @@ void main() async {
           value: authNotifier,
         ),
       ],
-      child: MyApp(
-        onboardingNotifier: onboardingNotifier,
-        authNotifier: authNotifier,
-      ),
+      child: MyApp(router: router),
     ),
   );
 }
 
 class MyApp extends StatelessWidget {
-  final OnboardingNotifier onboardingNotifier;
-  final AuthNotifier authNotifier;
-  late final GoRouter _router;
+  final GoRouter router;
 
-  MyApp({
-    super.key,
-    required this.onboardingNotifier,
-    required this.authNotifier,
-  }) : _router = createRouter(onboardingNotifier, authNotifier);
+  const MyApp({super.key, required this.router});
 
   @override
   Widget build(BuildContext context) {
@@ -109,7 +128,7 @@ class MyApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       title: 'CoreVia Mobile',
       theme: AppTheme.lightTheme,
-      routerConfig: _router,
+      routerConfig: router,
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,8 +28,12 @@ void main() async {
 
   // Initialize timezones and set device local timezone
   tz_data.initializeTimeZones();
-  final tzName = await FlutterTimezone.getLocalTimezone();
-  tz.setLocalLocation(tz.getLocation(tzName));
+  try {
+    final tzName = await FlutterTimezone.getLocalTimezone();
+    tz.setLocalLocation(tz.getLocation(tzName));
+  } catch (_) {
+    // Fallback to UTC if timezone is not recognized
+  }
 
   // Onboarding
   final prefs = await SharedPreferences.getInstance();

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,10 +5,16 @@
 import FlutterMacOS
 import Foundation
 
+import flutter_local_notifications
 import flutter_secure_storage_macos
+import flutter_timezone
+import path_provider_foundation
 import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
+  FlutterTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterTimezonePlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,9 @@ dependencies:
   flutter_chat_types: ^3.6.2
   http: ^1.6.0
   flutter_dotenv: ^6.0.0
+  flutter_local_notifications: ^18.0.1
+  timezone: ^0.10.0
+  flutter_timezone: ^3.0.1
   flutter_chat_core: ^2.8.0
   shared_preferences: ^2.5.4
   dio: ^5.9.1

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,15 @@
-import 'package:corevia_mobile/core/providers/notifiers.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:corevia_mobile/main.dart';
+import 'package:corevia_mobile/core/providers/notifiers.dart';
+import 'package:corevia_mobile/core/routes/app_router.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Créez des instances des notifiers au lieu de ValueNotifier
-    OnboardingNotifier onboardingNotifier = OnboardingNotifier(true); // Ou l'état que tu souhaites
-    AuthNotifier authNotifier = AuthNotifier(false); // Ou l'état que tu souhaites
+  testWidgets('App smoke test', (WidgetTester tester) async {
+    final onboardingNotifier = OnboardingNotifier(true);
+    final authNotifier = AuthNotifier(false);
+    final router = createRouter(onboardingNotifier, authNotifier);
 
-    // Pompez le widget avec les notifiers corrects
-    await tester.pumpWidget(MyApp(
-      onboardingNotifier: onboardingNotifier,
-      authNotifier: authNotifier,
-    ));
-
-    // Continue avec les tests...
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap sur l'icône '+' et triggerez un frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Vérifiez que le compteur a été incrémenté.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    await tester.pumpWidget(MyApp(router: router));
+    await tester.pumpAndSettle();
   });
 }

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,8 +7,11 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
+#include <flutter_timezone/flutter_timezone_plugin_c_api.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
+  FlutterTimezonePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterTimezonePluginCApi"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_windows
+  flutter_timezone
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
- Add flutter_local_notifications, timezone, flutter_timezone packages
- Create pillbox_notification.dart with Timer-based notification delivery
- Interactive notification actions (Pris/Ignorer) with API integration
- Schedule reminders for PENDING intakes, cancel on taken/skipped
- Add WidgetsBindingObserver on HomeScreen to refresh on app resume
- Configure Android permissions and core library desugaring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notes de version

* **Nouvelles Fonctionnalités**
  * Rappels de médicaments programmés avec actions intégrées (pris / ignoré).
  * Navigation depuis la notification vers l'écran d'accueil.
  * Actualisation automatique des prises lorsque l'app revient au premier plan.

* **Chores**
  * Permissions système ajoutées pour notifications et alarmes précises.
  * Prise en charge des fuseaux horaires et initialisation des notifications au démarrage.
  * Déploiement des composants nécessaires sur macOS et Windows.

* **Tests**
  * Test d'application mis à jour pour valider le lancement complet de l'app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->