### PR TITLE
feat: add French and English localization

### DIFF
--- a/lib/core/providers/notifiers.dart
+++ b/lib/core/providers/notifiers.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// Notifier pour l'état de l'onboarding
 class OnboardingNotifier extends ValueNotifier<bool> {
@@ -8,4 +10,30 @@ class OnboardingNotifier extends ValueNotifier<bool> {
 /// Notifier pour l'état d'authentification
 class AuthNotifier extends ValueNotifier<bool> {
   AuthNotifier(super.value);
+}
+
+/// Notifier pour la langue de l'application
+class LocaleNotifier extends ValueNotifier<Locale?> {
+  LocaleNotifier(super.value);
+
+  static const String storageKey = 'app_locale';
+
+  static Future<Locale?> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final languageCode = prefs.getString(storageKey);
+    if (languageCode == null || languageCode.isEmpty) {
+      return null;
+    }
+    return Locale(languageCode);
+  }
+
+  Future<void> updateLocale(Locale? locale) async {
+    value = locale;
+    final prefs = await SharedPreferences.getInstance();
+    if (locale == null) {
+      await prefs.remove(storageKey);
+    } else {
+      await prefs.setString(storageKey, locale.languageCode);
+    }
+  }
 }

--- a/lib/core/routes/app_router.dart
+++ b/lib/core/routes/app_router.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 
 // Les écrans
 import '../../features/calendar/presentation/screens/calendar_screen.dart';
@@ -208,7 +209,7 @@ GoRouter createRouter(
 
     errorBuilder: (context, state) => Scaffold(
       body: Center(
-        child: Text('Page not found: ${state.uri}'),
+        child: Text(context.l10n.pageNotFound(state.uri.toString())),
       ),
     ),
   );

--- a/lib/core/routes/app_router.dart
+++ b/lib/core/routes/app_router.dart
@@ -136,7 +136,12 @@ GoRouter createRouter(
           GoRoute(
             path: '/calendar',
             builder: (context, state) => CalendarScreen(
-              initialTab: state.uri.queryParameters['tab'] ?? 'schedule',
+              initialTab: () {
+                final tab = (state.uri.queryParameters['tab'] ?? 'schedule').toLowerCase();
+                return (tab == 'list' || tab == 'lists')
+                    ? CalendarTab.list
+                    : CalendarTab.programme;
+              }(),
             ),
           ),
           GoRoute(
@@ -161,10 +166,10 @@ GoRouter createRouter(
           final extra = state.extra as Map<String, dynamic>? ?? {};
           return BookingScreen(
             doctorId: extra['doctorId'] as String? ?? '',
-            doctorName: extra['doctorName'] as String? ?? 'Médecin',
+            doctorName: extra['doctorName'] as String? ?? context.l10n.doctor,
             specialty: extra['specialty'] as String? ?? '',
             imageUrl: extra['imageUrl'] as String? ?? '',
-            address: extra['address'] as String? ?? 'Adresse non renseignée',
+            address: extra['address'] as String? ?? context.l10n.notProvided,
           );
         },
       ),
@@ -174,10 +179,10 @@ GoRouter createRouter(
           final extra = state.extra as Map<String, dynamic>? ?? {};
           return BookingConfirmationScreen(
             doctorId: extra['doctorId'] as String? ?? '',
-            doctorName: extra['doctorName'] as String? ?? 'Médecin',
+            doctorName: extra['doctorName'] as String? ?? context.l10n.doctor,
             specialty: extra['specialty'] as String? ?? '',
             imageUrl: extra['imageUrl'] as String? ?? '',
-            address: extra['address'] as String? ?? 'Adresse non renseignée',
+            address: extra['address'] as String? ?? context.l10n.notProvided,
             date: extra['date'] as DateTime? ?? DateTime.now(),
             timeSlot: extra['timeSlot'] as String? ?? '',
           );

--- a/lib/core/utils/validators.dart
+++ b/lib/core/utils/validators.dart
@@ -66,12 +66,12 @@ class Validators {
 
     if (value.length < 8) {
       return l10n?.passwordMustBeBetween8And100Characters ??
-          'Password must be at least 8 characters long';
+          'Password must be between 8 and 100 characters long';
     }
 
     if (value.length > 100) {
       return l10n?.passwordMustBeBetween8And100Characters ??
-          'Password cannot exceed 100 characters';
+          'Password must be between 8 and 100 characters long';
     }
 
     if (requireStrongRules && !_lowercaseRegex.hasMatch(value)) {

--- a/lib/core/utils/validators.dart
+++ b/lib/core/utils/validators.dart
@@ -1,3 +1,5 @@
+import 'package:corevia_mobile/l10n/app_localizations.dart';
+
 class Validators {
   static final RegExp _emailRegex =
       RegExp(r'^[\w-]+(\.[\w-]+)*@([\w-]+\.)+[a-zA-Z]{2,7}$');
@@ -7,13 +9,13 @@ class Validators {
   static final RegExp _specialCharRegex =
       RegExp(r'[!@#$%^&*(),.?":{}|<>_\-\\/\[\]`~+=;]');
 
-  static String? validateEmail(String? value) {
+  static String? validateEmail(String? value, {AppLocalizations? l10n}) {
     if (value == null || value.trim().isEmpty) {
-      return 'Veuillez entrer votre adresse email';
+      return l10n?.pleaseEnterEmail ?? 'Please enter your email address';
     }
 
     if (!_emailRegex.hasMatch(value.trim())) {
-      return 'Veuillez entrer une adresse email valide';
+      return l10n?.pleaseEnterValidEmail ?? 'Please enter a valid email address';
     }
 
     return null;
@@ -21,29 +23,33 @@ class Validators {
 
   static String? validateRequired(
     String? value, {
-    String fieldName = 'Ce champ',
+    String fieldName = 'This field',
+    AppLocalizations? l10n,
   }) {
     if (value == null || value.trim().isEmpty) {
-      return '$fieldName est requis';
+      return l10n?.fieldRequired(fieldName) ?? '$fieldName is required';
     }
     return null;
   }
 
   static String? validateUsername(
     String? value, {
-    String fieldName = "Nom d'utilisateur",
+    String fieldName = 'Username',
+    AppLocalizations? l10n,
   }) {
     if (value == null || value.trim().isEmpty) {
-      return '$fieldName est requis';
+      return l10n?.fieldRequired(fieldName) ?? '$fieldName is required';
     }
 
     final normalized = value.trim();
     if (normalized.length < 2) {
-      return '$fieldName doit contenir au moins 2 caracteres';
+      return l10n?.fieldMustContainAtLeast(fieldName, 2) ??
+          '$fieldName must contain at least 2 characters';
     }
 
     if (normalized.length > 100) {
-      return '$fieldName ne peut pas depasser 100 caracteres';
+      return l10n?.fieldCannotExceed(fieldName, 100) ??
+          '$fieldName cannot exceed 100 characters';
     }
 
     return null;
@@ -52,33 +58,40 @@ class Validators {
   static String? validatePassword(
     String? value, {
     bool requireStrongRules = false,
+    AppLocalizations? l10n,
   }) {
     if (value == null || value.isEmpty) {
-      return 'Veuillez entrer un mot de passe';
+      return l10n?.pleaseEnterPassword ?? 'Please enter a password';
     }
 
     if (value.length < 8) {
-      return 'Le mot de passe doit contenir au moins 8 caracteres';
+      return l10n?.passwordMustBeBetween8And100Characters ??
+          'Password must be at least 8 characters long';
     }
 
     if (value.length > 100) {
-      return 'Le mot de passe ne peut pas depasser 100 caracteres';
+      return l10n?.passwordMustBeBetween8And100Characters ??
+          'Password cannot exceed 100 characters';
     }
 
     if (requireStrongRules && !_lowercaseRegex.hasMatch(value)) {
-      return 'Le mot de passe doit contenir au moins une minuscule';
+      return l10n?.passwordMustContainLowercase ??
+          'Password must contain at least one lowercase letter';
     }
 
     if (requireStrongRules && !_uppercaseRegex.hasMatch(value)) {
-      return 'Le mot de passe doit contenir au moins une majuscule';
+      return l10n?.passwordMustContainUppercase ??
+          'Password must contain at least one uppercase letter';
     }
 
     if (requireStrongRules && !_digitRegex.hasMatch(value)) {
-      return 'Le mot de passe doit contenir au moins un chiffre';
+      return l10n?.passwordMustContainDigit ??
+          'Password must contain at least one digit';
     }
 
     if (requireStrongRules && !_specialCharRegex.hasMatch(value)) {
-      return 'Le mot de passe doit contenir au moins un caractere special';
+      return l10n?.passwordMustContainSpecialCharacter ??
+          'Password must contain at least one special character';
     }
 
     return null;

--- a/lib/features/account/presentation/screens/account_screen.dart
+++ b/lib/features/account/presentation/screens/account_screen.dart
@@ -73,6 +73,60 @@ class _AccountScreenState extends State<AccountScreen> {
   String get _phone => _patientProfile?['phone'] as String? ?? '—';
   String get _dateOfBirth => _patientProfile?['dateOfBirth'] as String? ?? '—';
 
+  String _languageLabel(BuildContext context, Locale? locale) {
+    final languageCode = locale?.languageCode ??
+        Localizations.localeOf(context).languageCode;
+    return languageCode == 'en' ? context.l10n.english : context.l10n.french;
+  }
+
+  Future<void> _showLanguageSelector() async {
+    final localeNotifier = context.read<LocaleNotifier>();
+    final currentLocale = localeNotifier.value;
+    final selectedLanguageCode =
+        currentLocale?.languageCode ?? Localizations.localeOf(context).languageCode;
+
+    await showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      backgroundColor: Colors.white,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (sheetContext) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.language_outlined),
+                title: Text(context.l10n.language),
+              ),
+              RadioListTile<String>(
+                value: 'fr',
+                groupValue: selectedLanguageCode,
+                title: Text(context.l10n.french),
+                onChanged: (_) async {
+                  await localeNotifier.updateLocale(const Locale('fr'));
+                  if (sheetContext.mounted) Navigator.pop(sheetContext);
+                },
+              ),
+              RadioListTile<String>(
+                value: 'en',
+                groupValue: selectedLanguageCode,
+                title: Text(context.l10n.english),
+                onChanged: (_) async {
+                  await localeNotifier.updateLocale(const Locale('en'));
+                  if (sheetContext.mounted) Navigator.pop(sheetContext);
+                },
+              ),
+              const SizedBox(height: 12),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -138,7 +192,11 @@ class _AccountScreenState extends State<AccountScreen> {
                               _buildActionTile(
                                 icon: Icons.language_outlined,
                                 title: context.l10n.language,
-                                subtitle: context.l10n.french,
+                                subtitle: _languageLabel(
+                                  context,
+                                  context.watch<LocaleNotifier>().value,
+                                ),
+                                onTap: _showLanguageSelector,
                               ),
                             ],
                           ),

--- a/lib/features/account/presentation/screens/account_screen.dart
+++ b/lib/features/account/presentation/screens/account_screen.dart
@@ -11,6 +11,7 @@ import 'package:corevia_mobile/core/routes/route_persistence.dart';
 import '../../../../widgets/pro_member.dart';
 import 'package:corevia_mobile/core/theme/colors.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 import '../providers/user_provider.dart';
 import '../../../../widgets/initials_avatar.dart';
 
@@ -92,37 +93,37 @@ class _AccountScreenState extends State<AccountScreen> {
                           _buildProfileCard(),
                           const SizedBox(height: 20),
                           _buildSection(
-                            title: 'Informations du compte',
+                            title: context.l10n.accountInformation,
                             children: [
                               _buildInfoTile(
                                 icon: Icons.email_outlined,
-                                title: 'Email',
+                                title: context.l10n.email,
                                 value: _email,
                               ),
                               _buildInfoTile(
                                 icon: Icons.phone_outlined,
-                                title: 'Telephone',
+                                title: context.l10n.phone,
                                 value: _phone,
                               ),
                               _buildInfoTile(
                                 icon: Icons.cake_outlined,
-                                title: 'Date de naissance',
+                                title: context.l10n.dateOfBirth,
                                 value: _dateOfBirth,
                               ),
                               _buildActionTile(
                                 icon: LucideIcons.fileText,
-                                title: 'Documents',
+                                title: context.l10n.documents,
                                 onTap: () => context.push('/documents'),
                               ),
                             ],
                           ),
                           const SizedBox(height: 20),
                           _buildSection(
-                            title: 'Parametres',
+                            title: context.l10n.settings,
                             children: [
                               _buildActionTile(
                                 icon: Icons.notifications_outlined,
-                                title: 'Notifications',
+                                title: context.l10n.notifications,
                                 trailing: Switch(
                                   value: isNotificationsEnabled,
                                   onChanged: (value) =>
@@ -132,30 +133,30 @@ class _AccountScreenState extends State<AccountScreen> {
                               ),
                               _buildActionTile(
                                 icon: Icons.lock_outline,
-                                title: 'Confidentialite et securite',
+                                title: context.l10n.privacySecurity,
                               ),
                               _buildActionTile(
                                 icon: Icons.language_outlined,
-                                title: 'Langue',
-                                subtitle: 'Francais',
+                                title: context.l10n.language,
+                                subtitle: context.l10n.french,
                               ),
                             ],
                           ),
                           const SizedBox(height: 20),
                           _buildSection(
-                            title: 'Actions',
+                            title: context.l10n.actions,
                             children: [
                               _buildActionTile(
                                 icon: Icons.help_outline,
-                                title: 'Aide et support',
+                                title: context.l10n.helpSupport,
                               ),
                               _buildActionTile(
                                 icon: Icons.info_outline,
-                                title: 'A propos',
+                                title: context.l10n.about,
                               ),
                               _buildActionTile(
                                 icon: Icons.logout,
-                                title: 'Deconnexion',
+                                title: context.l10n.logout,
                                 iconColor: Colors.red,
                                 titleColor: Colors.red,
                                 onTap: () => _logout(),
@@ -190,10 +191,10 @@ class _AccountScreenState extends State<AccountScreen> {
           ),
         ],
       ),
-      child: const Row(
+      child: Row(
         children: [
           Text(
-            'My Account',
+            context.l10n.myAccount,
             style: TextStyle(
               fontSize: 28,
               fontWeight: FontWeight.bold,

--- a/lib/features/account/presentation/screens/account_screen.dart
+++ b/lib/features/account/presentation/screens/account_screen.dart
@@ -92,7 +92,7 @@ class _AccountScreenState extends State<AccountScreen> {
                           _buildProfileCard(),
                           const SizedBox(height: 20),
                           _buildSection(
-                            title: 'Account Information',
+                            title: 'Informations du compte',
                             children: [
                               _buildInfoTile(
                                 icon: Icons.email_outlined,
@@ -101,12 +101,12 @@ class _AccountScreenState extends State<AccountScreen> {
                               ),
                               _buildInfoTile(
                                 icon: Icons.phone_outlined,
-                                title: 'Phone',
+                                title: 'Telephone',
                                 value: _phone,
                               ),
                               _buildInfoTile(
                                 icon: Icons.cake_outlined,
-                                title: 'Date of Birth',
+                                title: 'Date de naissance',
                                 value: _dateOfBirth,
                               ),
                               _buildActionTile(
@@ -118,7 +118,7 @@ class _AccountScreenState extends State<AccountScreen> {
                           ),
                           const SizedBox(height: 20),
                           _buildSection(
-                            title: 'Settings',
+                            title: 'Parametres',
                             children: [
                               _buildActionTile(
                                 icon: Icons.notifications_outlined,
@@ -132,12 +132,12 @@ class _AccountScreenState extends State<AccountScreen> {
                               ),
                               _buildActionTile(
                                 icon: Icons.lock_outline,
-                                title: 'Privacy & Security',
+                                title: 'Confidentialite et securite',
                               ),
                               _buildActionTile(
                                 icon: Icons.language_outlined,
-                                title: 'Language',
-                                subtitle: 'English',
+                                title: 'Langue',
+                                subtitle: 'Francais',
                               ),
                             ],
                           ),
@@ -147,15 +147,15 @@ class _AccountScreenState extends State<AccountScreen> {
                             children: [
                               _buildActionTile(
                                 icon: Icons.help_outline,
-                                title: 'Help & Support',
+                                title: 'Aide et support',
                               ),
                               _buildActionTile(
                                 icon: Icons.info_outline,
-                                title: 'About',
+                                title: 'A propos',
                               ),
                               _buildActionTile(
                                 icon: Icons.logout,
-                                title: 'Logout',
+                                title: 'Deconnexion',
                                 iconColor: Colors.red,
                                 titleColor: Colors.red,
                                 onTap: () => _logout(),

--- a/lib/features/account/presentation/screens/account_screen.dart
+++ b/lib/features/account/presentation/screens/account_screen.dart
@@ -1,19 +1,20 @@
+import 'package:corevia_mobile/core/providers/notifiers.dart';
+import 'package:corevia_mobile/core/routes/route_persistence.dart';
+import 'package:corevia_mobile/core/theme/colors.dart';
+import 'package:corevia_mobile/features/ai_chat/data/rag_chat_storage.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
+import 'package:corevia_mobile/networking/api_service.dart';
+import 'package:corevia_mobile/networking/routes/user_routes.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:go_router/go_router.dart';
-import 'package:provider/provider.dart';
-import 'package:corevia_mobile/core/providers/notifiers.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:corevia_mobile/features/ai_chat/data/rag_chat_storage.dart';
-import 'package:corevia_mobile/networking/api_service.dart';
-import 'package:corevia_mobile/networking/routes/user_routes.dart';
-import 'package:corevia_mobile/core/routes/route_persistence.dart';
-import '../../../../widgets/pro_member.dart';
-import 'package:corevia_mobile/core/theme/colors.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
-import 'package:corevia_mobile/l10n/app_localizations.dart';
-import '../providers/user_provider.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
 import '../../../../widgets/initials_avatar.dart';
+import '../../../../widgets/pro_member.dart';
+import '../providers/user_provider.dart';
 
 class AccountScreen extends StatefulWidget {
   const AccountScreen({super.key});
@@ -87,40 +88,47 @@ class _AccountScreenState extends State<AccountScreen> {
 
     await showModalBottomSheet<void>(
       context: context,
+      isScrollControlled: true,
       showDragHandle: true,
       backgroundColor: Colors.white,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
       ),
       builder: (sheetContext) {
+        final mediaQuery = MediaQuery.of(sheetContext);
+        final bottomInset = mediaQuery.padding.bottom + kBottomNavigationBarHeight;
         return SafeArea(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              ListTile(
-                leading: const Icon(Icons.language_outlined),
-                title: Text(context.l10n.language),
-              ),
-              RadioListTile<String>(
-                value: 'fr',
-                groupValue: selectedLanguageCode,
-                title: Text(context.l10n.french),
-                onChanged: (_) async {
-                  await localeNotifier.updateLocale(const Locale('fr'));
-                  if (sheetContext.mounted) Navigator.pop(sheetContext);
-                },
-              ),
-              RadioListTile<String>(
-                value: 'en',
-                groupValue: selectedLanguageCode,
-                title: Text(context.l10n.english),
-                onChanged: (_) async {
-                  await localeNotifier.updateLocale(const Locale('en'));
-                  if (sheetContext.mounted) Navigator.pop(sheetContext);
-                },
-              ),
-              const SizedBox(height: 12),
-            ],
+          top: false,
+          child: SingleChildScrollView(
+            padding: EdgeInsets.only(bottom: bottomInset),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ListTile(
+                  leading: const Icon(Icons.language_outlined),
+                  title: Text(context.l10n.language),
+                ),
+                RadioListTile<String>(
+                  value: 'fr',
+                  groupValue: selectedLanguageCode,
+                  title: Text(context.l10n.french),
+                  onChanged: (_) async {
+                    await localeNotifier.updateLocale(const Locale('fr'));
+                    if (sheetContext.mounted) Navigator.pop(sheetContext);
+                  },
+                ),
+                RadioListTile<String>(
+                  value: 'en',
+                  groupValue: selectedLanguageCode,
+                  title: Text(context.l10n.english),
+                  onChanged: (_) async {
+                    await localeNotifier.updateLocale(const Locale('en'));
+                    if (sheetContext.mounted) Navigator.pop(sheetContext);
+                  },
+                ),
+                const SizedBox(height: 12),
+              ],
+            ),
           ),
         );
       },

--- a/lib/features/account/presentation/screens/edit_account_screen.dart
+++ b/lib/features/account/presentation/screens/edit_account_screen.dart
@@ -663,7 +663,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
                       valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
                     ),
                   )
-                : const Text(
+                : Text(
                 context.l10n.saveChanges,
                 style: TextStyle(
                       color: Colors.white,

--- a/lib/features/account/presentation/screens/edit_account_screen.dart
+++ b/lib/features/account/presentation/screens/edit_account_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:corevia_mobile/core/theme/colors.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import '../providers/user_provider.dart';
 
@@ -35,7 +36,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
     _phoneController = TextEditingController(text: user?.phone ?? '');
     _dobController = TextEditingController(text: user?.dateOfBirth ?? '');
     _addressController = TextEditingController(text: user?.address ?? '');
-    _selectedGender = user?.gender;
+    _selectedGender = _normalizeGender(user?.gender);
   }
 
   @override
@@ -47,6 +48,27 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
     _dobController.dispose();
     _addressController.dispose();
     super.dispose();
+  }
+
+  String? _normalizeGender(String? value) {
+    if (value == null) return null;
+    final normalized = value.trim().toLowerCase();
+    switch (normalized) {
+      case 'male':
+      case 'homme':
+      case 'm':
+        return 'Male';
+      case 'female':
+      case 'femme':
+      case 'f':
+        return 'Female';
+      case 'other':
+      case 'autre':
+      case 'o':
+        return 'Other';
+      default:
+        return ['Male', 'Female', 'Other'].contains(value) ? value : null;
+    }
   }
 
   Future<void> _saveChanges() async {
@@ -77,8 +99,8 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(success
-              ? 'Profil mis a jour avec succes !'
-              : 'Echec de la mise a jour du profil'),
+              ? context.l10n.profileUpdatedSuccessfully
+              : context.l10n.profileUpdateFailed),
           backgroundColor: success ? AppColors.green : Colors.red,
           behavior: SnackBarBehavior.floating,
           shape: RoundedRectangleBorder(
@@ -121,11 +143,11 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
                       // Champs de formulaire avec nouveau style
                       _buildTextField(
                         controller: _firstNameController,
-                        label: 'Prenom',
+                        label: context.l10n.firstName,
                         icon: Icons.person_outline,
                         validator: (value) {
                           if (value == null || value.isEmpty) {
-                            return 'Veuillez saisir votre prenom';
+                            return context.l10n.pleaseEnterFirstName;
                           }
                           return null;
                         },
@@ -135,11 +157,11 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
 
                       _buildTextField(
                         controller: _lastNameController,
-                        label: 'Nom',
+                        label: context.l10n.lastName,
                         icon: Icons.person_outline,
                         validator: (value) {
                           if (value == null || value.isEmpty) {
-                            return 'Veuillez saisir votre nom';
+                            return context.l10n.pleaseEnterLastName;
                           }
                           return null;
                         },
@@ -149,15 +171,15 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
 
                       _buildTextField(
                         controller: _emailController,
-                        label: 'Email',
+                        label: context.l10n.email,
                         icon: LucideIcons.mail,
                         keyboardType: TextInputType.emailAddress,
                         validator: (value) {
                           if (value == null || value.isEmpty) {
-                            return 'Veuillez saisir votre email';
+                            return context.l10n.pleaseEnterEmail;
                           }
                           if (!value.contains('@')) {
-                            return 'Veuillez saisir un email valide';
+                            return context.l10n.pleaseEnterValidEmail;
                           }
                           return null;
                         },
@@ -167,12 +189,12 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
 
                       _buildTextField(
                         controller: _phoneController,
-                        label: 'Telephone',
+                        label: context.l10n.phone,
                         icon: LucideIcons.phone,
                         keyboardType: TextInputType.phone,
                         validator: (value) {
                           if (value == null || value.isEmpty) {
-                            return 'Veuillez saisir votre numero de telephone';
+                            return context.l10n.pleaseEnterPhone;
                           }
                           return null;
                         },
@@ -193,7 +215,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
 
                       _buildTextField(
                         controller: _dobController,
-                        label: 'Date de naissance',
+                        label: context.l10n.dateOfBirth,
                         icon: LucideIcons.cake,
                         readOnly: true,
                         onTap: () async {
@@ -224,7 +246,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
 
                       _buildTextField(
                         controller: _addressController,
-                        label: 'Adresse',
+                        label: context.l10n.address,
                         icon: LucideIcons.mapPinHouse,
                         maxLines: 2,
                       ),
@@ -276,8 +298,8 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
             padding: EdgeInsets.zero,
           ),
           const SizedBox(width: 8),
-          const Text(
-            'Modifier le profil',
+          Text(
+            context.l10n.editProfile,
             style: TextStyle(
               fontSize: 28,
               fontWeight: FontWeight.bold,
@@ -322,7 +344,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
             onTap: () {
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
-                  content: const Text("Fonction de changement de photo"),
+                  content: Text(context.l10n.changeProfilePhoto),
                   behavior: SnackBarBehavior.floating,
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12),
@@ -454,7 +476,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
       child: DropdownButtonFormField<String>(
         initialValue: selectedGender,
         decoration: InputDecoration(
-          labelText: 'Genre',
+          labelText: context.l10n.gender,
           labelStyle: TextStyle(
             color: Colors.grey.shade600,
             fontSize: 15,
@@ -492,10 +514,10 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
             value: value,
             child: Text(
               value == 'Male'
-                  ? 'Homme'
+                  ? context.l10n.male
                   : value == 'Female'
-                      ? 'Femme'
-                      : 'Autre',
+                      ? context.l10n.female
+                      : context.l10n.other,
               style: const TextStyle(
                 fontSize: 16,
                 fontWeight: FontWeight.w500,
@@ -507,7 +529,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
         onChanged: onChanged,
         validator: (value) {
           if (value == null) {
-            return 'Veuillez selectionner votre genre';
+            return context.l10n.selectGender;
           }
           return null;
         },
@@ -533,8 +555,8 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
-            'Securite',
+          Text(
+            context.l10n.security,
             style: TextStyle(
               fontSize: 18,
               fontWeight: FontWeight.w700,
@@ -547,7 +569,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
             onTap: () {
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
-                  content: const Text('Page de changement de mot de passe'),
+                  content: Text(context.l10n.changePassword),
                   behavior: SnackBarBehavior.floating,
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12),
@@ -573,9 +595,9 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
                     ),
                   ),
                   const SizedBox(width: 16),
-                  const Expanded(
+                  Expanded(
                     child: Text(
-                      'Changer le mot de passe',
+                      context.l10n.changePassword,
                       style: TextStyle(
                         fontWeight: FontWeight.w600,
                         fontSize: 16,
@@ -610,8 +632,8 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
                 borderRadius: BorderRadius.circular(20),
               ),
             ),
-            child: const Text(
-              'Annuler',
+            child: Text(
+              context.l10n.cancel,
               style: TextStyle(
                 color: AppColors.green,
                 fontSize: 16,
@@ -642,8 +664,8 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
                     ),
                   )
                 : const Text(
-                    'Enregistrer les modifications',
-                    style: TextStyle(
+                context.l10n.saveChanges,
+                style: TextStyle(
                       color: Colors.white,
                       fontSize: 16,
                       fontWeight: FontWeight.w700,

--- a/lib/features/account/presentation/screens/edit_account_screen.dart
+++ b/lib/features/account/presentation/screens/edit_account_screen.dart
@@ -77,8 +77,8 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(success
-              ? 'Profile updated successfully!'
-              : 'Failed to update profile'),
+              ? 'Profil mis a jour avec succes !'
+              : 'Echec de la mise a jour du profil'),
           backgroundColor: success ? AppColors.green : Colors.red,
           behavior: SnackBarBehavior.floating,
           shape: RoundedRectangleBorder(
@@ -121,11 +121,11 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
                       // Champs de formulaire avec nouveau style
                       _buildTextField(
                         controller: _firstNameController,
-                        label: 'First Name',
+                        label: 'Prenom',
                         icon: Icons.person_outline,
                         validator: (value) {
                           if (value == null || value.isEmpty) {
-                            return 'Please enter your first name';
+                            return 'Veuillez saisir votre prenom';
                           }
                           return null;
                         },
@@ -135,11 +135,11 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
 
                       _buildTextField(
                         controller: _lastNameController,
-                        label: 'Last Name',
+                        label: 'Nom',
                         icon: Icons.person_outline,
                         validator: (value) {
                           if (value == null || value.isEmpty) {
-                            return 'Please enter your last name';
+                            return 'Veuillez saisir votre nom';
                           }
                           return null;
                         },
@@ -154,10 +154,10 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
                         keyboardType: TextInputType.emailAddress,
                         validator: (value) {
                           if (value == null || value.isEmpty) {
-                            return 'Please enter your email';
+                            return 'Veuillez saisir votre email';
                           }
                           if (!value.contains('@')) {
-                            return 'Please enter a valid email';
+                            return 'Veuillez saisir un email valide';
                           }
                           return null;
                         },
@@ -167,12 +167,12 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
 
                       _buildTextField(
                         controller: _phoneController,
-                        label: 'Phone',
+                        label: 'Telephone',
                         icon: LucideIcons.phone,
                         keyboardType: TextInputType.phone,
                         validator: (value) {
                           if (value == null || value.isEmpty) {
-                            return 'Please enter your phone number';
+                            return 'Veuillez saisir votre numero de telephone';
                           }
                           return null;
                         },
@@ -193,7 +193,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
 
                       _buildTextField(
                         controller: _dobController,
-                        label: 'Date of Birth',
+                        label: 'Date de naissance',
                         icon: LucideIcons.cake,
                         readOnly: true,
                         onTap: () async {
@@ -224,7 +224,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
 
                       _buildTextField(
                         controller: _addressController,
-                        label: 'Address',
+                        label: 'Adresse',
                         icon: LucideIcons.mapPinHouse,
                         maxLines: 2,
                       ),
@@ -277,7 +277,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
           ),
           const SizedBox(width: 8),
           const Text(
-            'Edit Profile',
+            'Modifier le profil',
             style: TextStyle(
               fontSize: 28,
               fontWeight: FontWeight.bold,
@@ -322,7 +322,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
             onTap: () {
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
-                  content: const Text('Change photo functionality'),
+                  content: const Text("Fonction de changement de photo"),
                   behavior: SnackBarBehavior.floating,
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12),
@@ -454,7 +454,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
       child: DropdownButtonFormField<String>(
         initialValue: selectedGender,
         decoration: InputDecoration(
-          labelText: 'Gender',
+          labelText: 'Genre',
           labelStyle: TextStyle(
             color: Colors.grey.shade600,
             fontSize: 15,
@@ -487,11 +487,15 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
             borderSide: const BorderSide(color: AppColors.green, width: 2),
           ),
         ),
-        items: <String>['Male', 'Female', 'Other'].map<DropdownMenuItem<String>>((String value) {
+        items: const <String>['Male', 'Female', 'Other'].map<DropdownMenuItem<String>>((String value) {
           return DropdownMenuItem<String>(
             value: value,
             child: Text(
-              value,
+              value == 'Male'
+                  ? 'Homme'
+                  : value == 'Female'
+                      ? 'Femme'
+                      : 'Autre',
               style: const TextStyle(
                 fontSize: 16,
                 fontWeight: FontWeight.w500,
@@ -503,7 +507,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
         onChanged: onChanged,
         validator: (value) {
           if (value == null) {
-            return 'Please select your gender';
+            return 'Veuillez selectionner votre genre';
           }
           return null;
         },
@@ -530,7 +534,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const Text(
-            'Security',
+            'Securite',
             style: TextStyle(
               fontSize: 18,
               fontWeight: FontWeight.w700,
@@ -543,7 +547,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
             onTap: () {
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
-                  content: const Text('Change password page'),
+                  content: const Text('Page de changement de mot de passe'),
                   behavior: SnackBarBehavior.floating,
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12),
@@ -571,7 +575,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
                   const SizedBox(width: 16),
                   const Expanded(
                     child: Text(
-                      'Change Password',
+                      'Changer le mot de passe',
                       style: TextStyle(
                         fontWeight: FontWeight.w600,
                         fontSize: 16,
@@ -607,7 +611,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
               ),
             ),
             child: const Text(
-              'Cancel',
+              'Annuler',
               style: TextStyle(
                 color: AppColors.green,
                 fontSize: 16,
@@ -638,7 +642,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
                     ),
                   )
                 : const Text(
-                    'Save Changes',
+                    'Enregistrer les modifications',
                     style: TextStyle(
                       color: Colors.white,
                       fontSize: 16,

--- a/lib/features/account/presentation/screens/edit_account_screen.dart
+++ b/lib/features/account/presentation/screens/edit_account_screen.dart
@@ -71,6 +71,19 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
     }
   }
 
+  String? _denormalizeGender(String? value) {
+    switch (value) {
+      case 'Male':
+        return 'male';
+      case 'Female':
+        return 'female';
+      case 'Other':
+        return 'other';
+      default:
+        return null;
+    }
+  }
+
   Future<void> _saveChanges() async {
     if (_formKey.currentState!.validate()) {
       setState(() {
@@ -83,7 +96,7 @@ class _EditAccountScreenState extends State<EditAccountScreen> {
         'name': fullName,
         'email': _emailController.text.trim(),
         'phone': _phoneController.text.trim(),
-        'gender': _selectedGender,
+        'gender': _denormalizeGender(_selectedGender),
         'dateOfBirth': _dobController.text.trim(),
         'address': _addressController.text.trim(),
       };

--- a/lib/features/ai_chat/domain/rag_agent.dart
+++ b/lib/features/ai_chat/domain/rag_agent.dart
@@ -11,22 +11,22 @@ class RagAgent {
 class RagAgents {
   static const medecinGeneraliste = RagAgent(
     id: 'medecin_generaliste',
-    label: 'Médecin généraliste',
+    label: 'General practitioner',
   );
 
   static const dermatologue = RagAgent(
     id: 'dermatologue',
-    label: 'Dermatologue',
+    label: 'Dermatologist',
   );
 
   static const nutritionniste = RagAgent(
     id: 'nutritionniste',
-    label: 'Nutritionniste',
+    label: 'Nutritionist',
   );
 
   static const psychologue = RagAgent(
     id: 'psychologue',
-    label: 'Psychologue',
+    label: 'Psychologist',
   );
 
   static const all = <RagAgent>[

--- a/lib/features/ai_chat/presentation/ai_chat_modal.dart
+++ b/lib/features/ai_chat/presentation/ai_chat_modal.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 
 import '../../pillbox/presentation/providers/pillbox_provider.dart';
 import '../data/ai_chat_service.dart';
@@ -250,8 +251,8 @@ class _AiChatModalState extends State<AiChatModal> {
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                const Text(
-                  'Assistant DocAI',
+                Text(
+                  context.l10n.docAiAssistant,
                   style: TextStyle(
                     fontSize: 17,
                     fontWeight: FontWeight.w700,
@@ -259,7 +260,7 @@ class _AiChatModalState extends State<AiChatModal> {
                   ),
                 ),
                 Text(
-                  _isStreaming ? 'En train d\'ecrire...' : 'En ligne',
+                  _isStreaming ? context.l10n.writingStatus : context.l10n.online,
                   style: TextStyle(
                     fontSize: 13,
                     color: _isStreaming ? const Color(0xFF34C759) : Colors.grey.shade500,
@@ -291,7 +292,7 @@ class _AiChatModalState extends State<AiChatModal> {
             Icon(Icons.chat_bubble_outline_rounded, size: 48, color: Colors.grey.shade300),
             const SizedBox(height: 12),
             Text(
-              'Posez votre question à DocAI',
+              context.l10n.askDocAi,
               style: TextStyle(
                 fontSize: 16,
                 color: Colors.grey.shade500,
@@ -338,7 +339,7 @@ class _AiChatModalState extends State<AiChatModal> {
                       ),
                       child: Center(
                         child: Text(
-                          'Tout approuver ($pendingCount)',
+                          '${context.l10n.approveAll} ($pendingCount)',
                           style: const TextStyle(
                             color: Colors.white,
                             fontSize: 14,
@@ -362,7 +363,7 @@ class _AiChatModalState extends State<AiChatModal> {
                       ),
                       child: const Center(
                         child: Text(
-                          'Tout refuser',
+                          context.l10n.rejectAll,
                           style: TextStyle(
                             color: Colors.white,
                             fontSize: 14,
@@ -400,11 +401,11 @@ class _AiChatModalState extends State<AiChatModal> {
                   onSubmitted: (_) => _sendMessage(),
                   maxLines: 4,
                   minLines: 1,
-                  decoration: const InputDecoration(
-                    hintText: 'Votre message...',
-                    hintStyle: TextStyle(color: Color(0xFF9CA3AF)),
+                  decoration: InputDecoration(
+                    hintText: context.l10n.writeMessage,
+                    hintStyle: const TextStyle(color: Color(0xFF9CA3AF)),
                     border: InputBorder.none,
-                    contentPadding: EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
                   ),
                   style: const TextStyle(fontSize: 15, color: Color(0xFF1D1D1F)),
                 ),

--- a/lib/features/ai_chat/presentation/ai_chat_modal.dart
+++ b/lib/features/ai_chat/presentation/ai_chat_modal.dart
@@ -361,7 +361,7 @@ class _AiChatModalState extends State<AiChatModal> {
                         color: const Color(0xFFEF4444),
                         borderRadius: BorderRadius.circular(12),
                       ),
-                      child: const Center(
+                      child: Center(
                         child: Text(
                           context.l10n.rejectAll,
                           style: TextStyle(

--- a/lib/features/ai_chat/presentation/ai_chat_modal.dart
+++ b/lib/features/ai_chat/presentation/ai_chat_modal.dart
@@ -251,7 +251,7 @@ class _AiChatModalState extends State<AiChatModal> {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 const Text(
-                  'DocAI Assistant',
+                  'Assistant DocAI',
                   style: TextStyle(
                     fontSize: 17,
                     fontWeight: FontWeight.w700,
@@ -291,7 +291,7 @@ class _AiChatModalState extends State<AiChatModal> {
             Icon(Icons.chat_bubble_outline_rounded, size: 48, color: Colors.grey.shade300),
             const SizedBox(height: 12),
             Text(
-              'Posez votre question a DocAI',
+              'Posez votre question à DocAI',
               style: TextStyle(
                 fontSize: 16,
                 color: Colors.grey.shade500,

--- a/lib/features/ai_chat/presentation/widgets/chat_bubble.dart
+++ b/lib/features/ai_chat/presentation/widgets/chat_bubble.dart
@@ -228,7 +228,7 @@ class _ToolCallCard extends StatelessWidget {
               ),
             ],
             if (isApproved)
-              const Padding(
+              Padding(
                 padding: EdgeInsets.only(top: 6),
                 child: Text(
                   context.l10n.confirmed,
@@ -236,7 +236,7 @@ class _ToolCallCard extends StatelessWidget {
                 ),
               ),
             if (isRejected)
-              const Padding(
+              Padding(
                 padding: EdgeInsets.only(top: 6),
                 child: Text(
                   context.l10n.cancelled,

--- a/lib/features/ai_chat/presentation/widgets/chat_bubble.dart
+++ b/lib/features/ai_chat/presentation/widgets/chat_bubble.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 
 import '../../domain/chat_message.dart';
 
@@ -210,7 +211,7 @@ class _ToolCallCard extends StatelessWidget {
                 children: [
                   Expanded(
                     child: _ActionButton(
-                      label: 'Approuver',
+                      label: context.l10n.approveAll,
                       color: const Color(0xFF34C759),
                       onTap: onApprove,
                     ),
@@ -218,7 +219,7 @@ class _ToolCallCard extends StatelessWidget {
                   const SizedBox(width: 8),
                   Expanded(
                     child: _ActionButton(
-                      label: 'Refuser',
+                      label: context.l10n.rejectAll,
                       color: const Color(0xFFEF4444),
                       onTap: onReject,
                     ),
@@ -230,16 +231,16 @@ class _ToolCallCard extends StatelessWidget {
               const Padding(
                 padding: EdgeInsets.only(top: 6),
                 child: Text(
-                  'Action approuvée',
-                  style: TextStyle(fontSize: 12, color: Color(0xFF16A34A)),
+                  context.l10n.confirmed,
+                  style: const TextStyle(fontSize: 12, color: Color(0xFF16A34A)),
                 ),
               ),
             if (isRejected)
               const Padding(
                 padding: EdgeInsets.only(top: 6),
                 child: Text(
-                  'Action refusée',
-                  style: TextStyle(fontSize: 12, color: Color(0xFFDC2626)),
+                  context.l10n.cancelled,
+                  style: const TextStyle(fontSize: 12, color: Color(0xFFDC2626)),
                 ),
               ),
           ],

--- a/lib/features/ai_chat/presentation/widgets/chat_bubble.dart
+++ b/lib/features/ai_chat/presentation/widgets/chat_bubble.dart
@@ -211,7 +211,7 @@ class _ToolCallCard extends StatelessWidget {
                 children: [
                   Expanded(
                     child: _ActionButton(
-                      label: context.l10n.approveAll,
+                      label: context.l10n.approve,
                       color: const Color(0xFF34C759),
                       onTap: onApprove,
                     ),
@@ -219,7 +219,7 @@ class _ToolCallCard extends StatelessWidget {
                   const SizedBox(width: 8),
                   Expanded(
                     child: _ActionButton(
-                      label: context.l10n.rejectAll,
+                      label: context.l10n.reject,
                       color: const Color(0xFFEF4444),
                       onTap: onReject,
                     ),
@@ -231,7 +231,7 @@ class _ToolCallCard extends StatelessWidget {
               Padding(
                 padding: EdgeInsets.only(top: 6),
                 child: Text(
-                  context.l10n.confirmed,
+                  context.l10n.approved,
                   style: const TextStyle(fontSize: 12, color: Color(0xFF16A34A)),
                 ),
               ),
@@ -239,7 +239,7 @@ class _ToolCallCard extends StatelessWidget {
               Padding(
                 padding: EdgeInsets.only(top: 6),
                 child: Text(
-                  context.l10n.cancelled,
+                  context.l10n.rejected,
                   style: const TextStyle(fontSize: 12, color: Color(0xFFDC2626)),
                 ),
               ),

--- a/lib/features/auth/domain/models/register_model.dart
+++ b/lib/features/auth/domain/models/register_model.dart
@@ -16,19 +16,19 @@ class RegisterModel {
     final normalizedLastName = lastName.trim();
 
     if (normalizedFirstName.length < 2 || normalizedFirstName.length > 100) {
-      throw ArgumentError('Le prenom doit contenir entre 2 et 100 caracteres');
+      throw ArgumentError('First name must be between 2 and 100 characters');
     }
 
     if (normalizedLastName.length < 2 || normalizedLastName.length > 100) {
-      throw ArgumentError('Le nom doit contenir entre 2 et 100 caracteres');
+      throw ArgumentError('Last name must be between 2 and 100 characters');
     }
 
     if (!_isValidEmail(email)) {
-      throw ArgumentError('Email invalide');
+      throw ArgumentError('Invalid email');
     }
 
     if (password.length < 8 || password.length > 100) {
-      throw ArgumentError('Le mot de passe doit contenir entre 8 et 100 caracteres');
+      throw ArgumentError('Password must be between 8 and 100 characters');
     }
 
     if (!_hasLowercase(password) ||
@@ -36,12 +36,12 @@ class RegisterModel {
         !_hasDigit(password) ||
         !_hasSpecialChar(password)) {
       throw ArgumentError(
-        'Le mot de passe doit contenir minuscule, majuscule, chiffre et caractere special',
+        'Password must contain lowercase, uppercase, digit, and special character',
       );
     }
 
     if (password != confirmPassword) {
-      throw ArgumentError('Les mots de passe ne correspondent pas');
+      throw ArgumentError('Passwords do not match');
     }
   }
 

--- a/lib/features/auth/presentation/screens/login_screen.dart
+++ b/lib/features/auth/presentation/screens/login_screen.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:corevia_mobile/features/auth/presentation/screens/register_screen.dart';
 import 'package:corevia_mobile/features/auth/presentation/screens/reset_password_screen.dart';
 import 'package:corevia_mobile/features/account/presentation/providers/user_provider.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import '../controllers/login_controller.dart';
 
@@ -77,8 +78,8 @@ class LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin 
           context.go('/home');
         } else {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Email ou mot de passe incorrect'),
+          SnackBar(
+            content: Text(context.l10n.invalidCredentials),
             backgroundColor: Color(0xFFFF3B30),
             behavior: SnackBarBehavior.floating,
           ),
@@ -89,7 +90,7 @@ class LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin 
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('Erreur: ${e.toString()}'),
+            content: Text(context.l10n.genericError(e.toString())),
             backgroundColor: Color(0xFFFF3B30),
             behavior: SnackBarBehavior.floating,
           ),
@@ -156,7 +157,7 @@ class LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin 
                           ),
                           SizedBox(height: 8),
                           Text(
-                            'Connectez-vous pour continuer',
+                            context.l10n.connectToContinue,
                             style: TextStyle(
                               fontSize: 17,
                               color: Colors.grey[600],
@@ -167,7 +168,7 @@ class LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin 
                           
                           _buildModernTextField(
                             controller: _emailController,
-                            label: 'Email',
+                            label: context.l10n.email,
                             icon: Icons.email_outlined,
                             keyboardType: TextInputType.emailAddress,
                             validator: Validators.validateEmail,
@@ -177,7 +178,7 @@ class LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin 
                           
                           _buildModernTextField(
                             controller: _passwordController,
-                            label: 'Mot de passe',
+                            label: context.l10n.password,
                             icon: Icons.lock_outline_rounded,
                             obscureText: _obscurePassword,
                             suffixIcon: IconButton(
@@ -192,7 +193,7 @@ class LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin 
                             validator: (value) =>
                                 Validators.validateRequired(
                               value,
-                              fieldName: 'Le mot de passe',
+                              fieldName: context.l10n.password,
                             ),
                           ),
                           
@@ -220,9 +221,9 @@ class LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin 
                                   ),
                                 );
                               },
-                              child: const Text(
-                                'Mot de passe oublié?',
-                                style: TextStyle(
+                              child: Text(
+                                context.l10n.forgotPassword,
+                                style: const TextStyle(
                                   color: Color(0xFF34C759),
                                   fontWeight: FontWeight.w600,
                                   fontSize: 15,

--- a/lib/features/auth/presentation/screens/login_screen.dart
+++ b/lib/features/auth/presentation/screens/login_screen.dart
@@ -86,11 +86,13 @@ class LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin 
         );
         }
       }
-    } catch (e) {
+    } catch (e, st) {
+      debugPrint('Login error: $e');
+      debugPrintStack(stackTrace: st);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(context.l10n.genericError(e.toString())),
+            content: Text(context.l10n.genericErrorNoDetails),
             backgroundColor: Color(0xFFFF3B30),
             behavior: SnackBarBehavior.floating,
           ),

--- a/lib/features/auth/presentation/screens/login_screen.dart
+++ b/lib/features/auth/presentation/screens/login_screen.dart
@@ -147,7 +147,7 @@ class LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin 
                         crossAxisAlignment: CrossAxisAlignment.stretch,
                         children: [
                           Text(
-                            'Bienvenue',
+                            context.l10n.welcome,
                             style: TextStyle(
                               fontSize: 36,
                               fontWeight: FontWeight.w800,
@@ -171,7 +171,10 @@ class LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin 
                             label: context.l10n.email,
                             icon: Icons.email_outlined,
                             keyboardType: TextInputType.emailAddress,
-                            validator: Validators.validateEmail,
+                            validator: (value) => Validators.validateEmail(
+                              value,
+                              l10n: context.l10n,
+                            ),
                           ),
                           
                           SizedBox(height: 20),
@@ -242,7 +245,7 @@ class LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin 
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
                               Text(
-                                'Pas encore de compte? ',
+                                context.l10n.noAccountYet,
                                 style: TextStyle(
                                   fontSize: 15,
                                   color: Colors.grey[700],
@@ -271,7 +274,7 @@ class LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin 
                                   );
                                 },
                                 child: Text(
-                                  'S\'inscrire',
+                                  context.l10n.signUp,
                                   style: TextStyle(
                                     fontSize: 15,
                                     color: Color(0xFF34C759),
@@ -401,7 +404,7 @@ class LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin 
                 ),
               )
             : Text(
-                'Se connecter',
+                context.l10n.signIn,
                 style: TextStyle(
                   fontSize: 18,
                   fontWeight: FontWeight.w700,

--- a/lib/features/auth/presentation/screens/register_screen.dart
+++ b/lib/features/auth/presentation/screens/register_screen.dart
@@ -150,11 +150,13 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
           );
         }
       }
-    } catch (e) {
+    } catch (e, st) {
+      debugPrint('Register error: $e');
+      debugPrintStack(stackTrace: st);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(context.l10n.genericError(e.toString())),
+            content: Text(context.l10n.pleaseTryAgain),
             backgroundColor: Color(0xFFFF3B30),
             behavior: SnackBarBehavior.floating,
           ),

--- a/lib/features/auth/presentation/screens/register_screen.dart
+++ b/lib/features/auth/presentation/screens/register_screen.dart
@@ -70,29 +70,41 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
   }
 
   String? _validateEmail(String? value) {
-    return Validators.validateEmail(value);
+    return Validators.validateEmail(value, l10n: context.l10n);
   }
 
   String? _validatePassword(String? value) {
-    return Validators.validatePassword(value, requireStrongRules: true);
+    return Validators.validatePassword(
+      value,
+      requireStrongRules: true,
+      l10n: context.l10n,
+    );
   }
 
   String? _validateConfirmPassword(String? value) {
-    if (value == null || value.isEmpty) return 'Confirmation requise';
-    if (value != _passwordController.text) return 'Mots de passe differents';
+    if (value == null || value.isEmpty) return context.l10n.confirmationRequired;
+    if (value != _passwordController.text) return context.l10n.passwordsDifferent;
     return null;
   }
 
   Future<void> _register() async {
     final firstNameError =
-        Validators.validateUsername(_firstNameController.text, fieldName: 'Prenom');
+        Validators.validateUsername(
+          _firstNameController.text,
+          fieldName: context.l10n.firstName,
+          l10n: context.l10n,
+        );
     if (firstNameError != null) {
       _showValidationError(firstNameError);
       return;
     }
 
     final lastNameError =
-        Validators.validateUsername(_lastNameController.text, fieldName: context.l10n.lastName);
+        Validators.validateUsername(
+          _lastNameController.text,
+          fieldName: context.l10n.lastName,
+          l10n: context.l10n,
+        );
     if (lastNameError != null) {
       _showValidationError(lastNameError);
       return;
@@ -158,14 +170,22 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
   void _nextStep() {
     if (_currentStep == 0) {
       final firstNameError =
-          Validators.validateUsername(_firstNameController.text, fieldName: 'Prenom');
+          Validators.validateUsername(
+            _firstNameController.text,
+            fieldName: context.l10n.firstName,
+            l10n: context.l10n,
+          );
       if (firstNameError != null) {
         _showValidationError(firstNameError);
         return;
       }
 
       final lastNameError =
-          Validators.validateUsername(_lastNameController.text, fieldName: context.l10n.lastName);
+          Validators.validateUsername(
+            _lastNameController.text,
+            fieldName: context.l10n.lastName,
+            l10n: context.l10n,
+          );
       if (lastNameError != null) {
         _showValidationError(lastNameError);
         return;
@@ -281,7 +301,7 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
           Expanded(
             child: Center(
               child: Text(
-                'Créer un compte',
+                context.l10n.createAccount,
                 style: TextStyle(
                   fontSize: 22,
                   fontWeight: FontWeight.w800,
@@ -683,7 +703,7 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
                   ),
                 ),
                 child: Text(
-                  'Retour',
+                  context.l10n.back,
                   style: TextStyle(
                     fontSize: 17,
                     fontWeight: FontWeight.w700,
@@ -722,7 +742,7 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
                 ),
               ),
               child: Text(
-                'Suivant',
+                context.l10n.next,
                 style: TextStyle(
                   fontSize: 17,
                   fontWeight: FontWeight.w700,
@@ -774,7 +794,7 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   Text(
-                    'Créer mon compte',
+                    context.l10n.createMyAccount,
                     style: TextStyle(
                       fontSize: 18,
                       fontWeight: FontWeight.w700,

--- a/lib/features/auth/presentation/screens/register_screen.dart
+++ b/lib/features/auth/presentation/screens/register_screen.dart
@@ -5,6 +5,7 @@ import 'package:corevia_mobile/features/account/presentation/providers/user_prov
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 import '../controllers/register_controller.dart';
 
 import 'dart:math' as math;
@@ -91,7 +92,7 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
     }
 
     final lastNameError =
-        Validators.validateUsername(_lastNameController.text, fieldName: 'Nom');
+        Validators.validateUsername(_lastNameController.text, fieldName: context.l10n.lastName);
     if (lastNameError != null) {
       _showValidationError(lastNameError);
       return;
@@ -129,11 +130,11 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
           context.go('/home');
         } else {
           ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('Echec de l\'inscription. Veuillez reessayer.'),
-              backgroundColor: Color(0xFFFF3B30),
-              behavior: SnackBarBehavior.floating,
-            ),
+          SnackBar(
+            content: Text(context.l10n.registrationFailed),
+            backgroundColor: Color(0xFFFF3B30),
+            behavior: SnackBarBehavior.floating,
+          ),
           );
         }
       }
@@ -141,7 +142,7 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('Erreur: ${e.toString()}'),
+            content: Text(context.l10n.genericError(e.toString())),
             backgroundColor: Color(0xFFFF3B30),
             behavior: SnackBarBehavior.floating,
           ),
@@ -164,7 +165,7 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
       }
 
       final lastNameError =
-          Validators.validateUsername(_lastNameController.text, fieldName: 'Nom');
+          Validators.validateUsername(_lastNameController.text, fieldName: context.l10n.lastName);
       if (lastNameError != null) {
         _showValidationError(lastNameError);
         return;
@@ -412,7 +413,7 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
           ),
           SizedBox(height: 32),
           Text(
-            'Informations personnelles',
+            context.l10n.personalInformation,
             textAlign: TextAlign.center,
             style: TextStyle(
               fontSize: 28,
@@ -423,7 +424,7 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
           ),
           SizedBox(height: 8),
           Text(
-            'Comment devons-nous vous appeler?',
+            context.l10n.howShouldWeCallYou,
             textAlign: TextAlign.center,
             style: TextStyle(
               fontSize: 16,
@@ -434,13 +435,13 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
           SizedBox(height: 48),
           _buildStepTextField(
             controller: _firstNameController,
-            label: 'Prénom',
+            label: context.l10n.firstName,
             icon: Icons.person_outline,
           ),
           SizedBox(height: 20),
           _buildStepTextField(
             controller: _lastNameController,
-            label: 'Nom',
+            label: context.l10n.lastName,
             icon: Icons.person_outline,
           ),
           SizedBox(height: 40),
@@ -484,7 +485,7 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
           ),
           SizedBox(height: 32),
           Text(
-            'Votre email',
+            context.l10n.yourEmail,
             textAlign: TextAlign.center,
             style: TextStyle(
               fontSize: 28,
@@ -495,7 +496,7 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
           ),
           SizedBox(height: 8),
           Text(
-            'Nous l\'utiliserons pour vous connecter',
+            context.l10n.weWillUseItToConnect,
             textAlign: TextAlign.center,
             style: TextStyle(
               fontSize: 16,
@@ -506,7 +507,7 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
           SizedBox(height: 48),
           _buildStepTextField(
             controller: _emailController,
-            label: 'Email',
+            label: context.l10n.email,
             icon: Icons.email_outlined,
             keyboardType: TextInputType.emailAddress,
             validator: _validateEmail,
@@ -554,7 +555,7 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
             ),
             SizedBox(height: 32),
             Text(
-              'Sécurisez votre compte',
+              context.l10n.secureYourAccount,
               textAlign: TextAlign.center,
               style: TextStyle(
                 fontSize: 28,
@@ -565,7 +566,7 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
             ),
             SizedBox(height: 8),
             Text(
-              'Choisissez un mot de passe fort',
+              context.l10n.chooseStrongPassword,
               textAlign: TextAlign.center,
               style: TextStyle(
                 fontSize: 16,
@@ -576,7 +577,7 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
             SizedBox(height: 48),
             _buildStepTextField(
               controller: _passwordController,
-              label: 'Mot de passe',
+              label: context.l10n.password,
               icon: Icons.lock_outline_rounded,
               obscureText: _obscurePassword,
               validator: _validatePassword,
@@ -591,7 +592,7 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
             SizedBox(height: 20),
             _buildStepTextField(
               controller: _confirmPasswordController,
-              label: 'Confirmer le mot de passe',
+              label: context.l10n.confirmPassword,
               icon: Icons.lock_outline_rounded,
               obscureText: _obscureConfirmPassword,
               validator: _validateConfirmPassword,
@@ -788,4 +789,3 @@ class _RegisterScreenState extends State<RegisterScreen> with TickerProviderStat
     );
   }
 }
-

--- a/lib/features/auth/presentation/screens/reset_password_screen.dart
+++ b/lib/features/auth/presentation/screens/reset_password_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'dart:math' as math;
 import 'package:corevia_mobile/core/utils/validators.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 
 class ResetPasswordScreen extends StatefulWidget {
   const ResetPasswordScreen({super.key});
@@ -63,10 +64,10 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> with TickerPr
               children: [
                 Icon(Icons.check_circle, color: Colors.white),
                 SizedBox(width: 12),
-                Expanded(
-                  child: Text(
-                    'Email envoyé avec succès!',
-                    style: TextStyle(fontWeight: FontWeight.w600),
+                  Expanded(
+                    child: Text(
+                      context.l10n.emailSentSuccess,
+                      style: const TextStyle(fontWeight: FontWeight.w600),
                   ),
                 ),
               ],
@@ -82,7 +83,7 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> with TickerPr
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('Erreur: ${e.toString()}'),
+            content: Text(context.l10n.genericError(e.toString())),
             backgroundColor: Color(0xFFFF3B30),
             behavior: SnackBarBehavior.floating,
             shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
@@ -273,9 +274,9 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> with TickerPr
           ),
           SizedBox(height: 40),
           Text(
-            'Mot de passe oublié?',
+            context.l10n.forgotPassword,
             textAlign: TextAlign.center,
-            style: TextStyle(
+            style: const TextStyle(
               fontSize: 32,
               fontWeight: FontWeight.w800,
               color: Color(0xFF1D1D1F),
@@ -284,7 +285,7 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> with TickerPr
           ),
           SizedBox(height: 12),
           Text(
-            'Pas de souci! Entrez votre adresse email et nous vous enverrons un lien pour réinitialiser votre mot de passe',
+            'Pas de souci ! Entrez votre adresse email et nous vous enverrons un lien pour réinitialiser votre mot de passe',
             textAlign: TextAlign.center,
             style: TextStyle(
               fontSize: 16,
@@ -296,7 +297,7 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> with TickerPr
           SizedBox(height: 48),
           _buildModernTextField(
             controller: _emailController,
-            label: 'Email',
+            label: context.l10n.email,
             icon: Icons.email_outlined,
             keyboardType: TextInputType.emailAddress,
             validator: Validators.validateEmail,
@@ -319,8 +320,8 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> with TickerPr
                 ),
                 SizedBox(width: 8),
                 Text(
-                  'Retour à la connexion',
-                  style: TextStyle(
+                  context.l10n.back,
+                  style: const TextStyle(
                     fontSize: 16,
                     color: Color(0xFF34C759),
                     fontWeight: FontWeight.w600,
@@ -371,9 +372,9 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> with TickerPr
         ),
         SizedBox(height: 40),
         Text(
-          'Email envoyé!',
+          context.l10n.emailSent,
           textAlign: TextAlign.center,
-          style: TextStyle(
+          style: const TextStyle(
             fontSize: 32,
             fontWeight: FontWeight.w800,
             color: Color(0xFF1D1D1F),
@@ -458,8 +459,8 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> with TickerPr
               ),
             ),
             child: Text(
-              'Retour à la connexion',
-              style: TextStyle(
+              context.l10n.back,
+              style: const TextStyle(
                 fontSize: 18,
                 fontWeight: FontWeight.w700,
                 color: Colors.white,

--- a/lib/features/auth/presentation/screens/reset_password_screen.dart
+++ b/lib/features/auth/presentation/screens/reset_password_screen.dart
@@ -79,11 +79,13 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> with TickerPr
           ),
         );
       }
-    } catch (e) {
+    } catch (e, st) {
+      debugPrint('Reset password error: $e');
+      debugPrintStack(stackTrace: st);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(context.l10n.genericError(e.toString())),
+            content: Text(context.l10n.genericErrorNoDetails),
             backgroundColor: Color(0xFFFF3B30),
             behavior: SnackBarBehavior.floating,
             shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),

--- a/lib/features/auth/presentation/screens/reset_password_screen.dart
+++ b/lib/features/auth/presentation/screens/reset_password_screen.dart
@@ -155,7 +155,7 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> with TickerPr
           Expanded(
             child: Center(
               child: Text(
-                'Réinitialisation',
+                context.l10n.resetPasswordTitle,
                 style: TextStyle(
                   fontSize: 22,
                   fontWeight: FontWeight.w800,
@@ -285,7 +285,7 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> with TickerPr
           ),
           SizedBox(height: 12),
           Text(
-            'Pas de souci ! Entrez votre adresse email et nous vous enverrons un lien pour réinitialiser votre mot de passe',
+            context.l10n.resetPasswordHelp,
             textAlign: TextAlign.center,
             style: TextStyle(
               fontSize: 16,
@@ -300,7 +300,10 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> with TickerPr
             label: context.l10n.email,
             icon: Icons.email_outlined,
             keyboardType: TextInputType.emailAddress,
-            validator: Validators.validateEmail,
+            validator: (value) => Validators.validateEmail(
+              value,
+              l10n: context.l10n,
+            ),
           ),
           SizedBox(height: 32),
           _buildGradientButton(),
@@ -401,7 +404,7 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> with TickerPr
               ),
               SizedBox(height: 16),
               Text(
-                'Nous avons envoyé un lien de réinitialisation à',
+                context.l10n.resetEmailSentTo(_emailController.text),
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   fontSize: 15,
@@ -410,19 +413,9 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> with TickerPr
                   height: 1.5,
                 ),
               ),
-              SizedBox(height: 8),
-              Text(
-                _emailController.text,
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  fontSize: 16,
-                  color: Color(0xFF007AFF),
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
               SizedBox(height: 16),
               Text(
-                'Vérifiez votre boîte de réception et cliquez sur le lien pour réinitialiser votre mot de passe',
+                context.l10n.resetCheckInbox,
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   fontSize: 14,
@@ -485,7 +478,7 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> with TickerPr
                   ),
                 )
               : Text(
-                  'Renvoyer l\'email',
+                  context.l10n.resendEmail,
                   style: TextStyle(
                     fontSize: 15,
                     color: Color(0xFF007AFF),
@@ -599,7 +592,7 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> with TickerPr
                   Icon(Icons.email_outlined, color: Colors.white, size: 22),
                   SizedBox(width: 12),
                   Text(
-                    'Envoyer le lien',
+                    context.l10n.sendLink,
                     style: TextStyle(
                       fontSize: 18,
                       fontWeight: FontWeight.w700,

--- a/lib/features/booking/presentation/screens/appointments_screen.dart
+++ b/lib/features/booking/presentation/screens/appointments_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 
 import '../../domain/entities/appointment.dart';
@@ -85,23 +86,22 @@ class _AppointmentsScreenState extends State<AppointmentsScreen>
                           : TabBarView(
                               controller: _tabController,
                               children: [
-                                _buildAppointmentsList(
+                              _buildAppointmentsList(
                                   appointments: upcoming,
-                                  emptyTitle: 'Aucun rendez-vous a venir',
-                                  emptySubtitle:
-                                      'Prenez un rendez-vous depuis la liste des medecins.',
+                                  emptyTitle: context.l10n.noUpcomingAppointments,
+                                  emptySubtitle: context.l10n.bookFromDoctorsList,
                                 ),
                                 _buildAppointmentsList(
                                   appointments: past,
-                                  emptyTitle: 'Aucun rendez-vous passe',
+                                  emptyTitle: context.l10n.noPastAppointments,
                                   emptySubtitle:
-                                      'Vos consultations terminees apparaitront ici.',
+                                      context.l10n.pastConsultationsWillAppearHere,
                                 ),
                                 _buildAppointmentsList(
                                   appointments: cancelled,
-                                  emptyTitle: 'Aucun rendez-vous annule',
+                                  emptyTitle: context.l10n.noCancelledAppointments,
                                   emptySubtitle:
-                                      'Les rendez-vous annules apparaitront ici.',
+                                      context.l10n.cancelledAppointmentsWillAppearHere,
                                 ),
                               ],
                             ),
@@ -127,10 +127,10 @@ class _AppointmentsScreenState extends State<AppointmentsScreen>
             onTap: _handleBack,
           ),
           const SizedBox(width: 12),
-          const Expanded(
+          Expanded(
             child: Text(
-              'Mes rendez-vous',
-              style: TextStyle(
+              context.l10n.myAppointments,
+              style: const TextStyle(
                 fontSize: 24,
                 fontWeight: FontWeight.w800,
                 color: Color(0xFF111827),
@@ -157,7 +157,7 @@ class _AppointmentsScreenState extends State<AppointmentsScreen>
         children: [
           Expanded(
             child: _SummaryCard(
-              label: 'Total',
+              label: context.l10n.total,
               value: total,
               color: const Color(0xFF0EA5E9),
               icon: Icons.calendar_month_rounded,
@@ -166,7 +166,7 @@ class _AppointmentsScreenState extends State<AppointmentsScreen>
           const SizedBox(width: 10),
           Expanded(
             child: _SummaryCard(
-              label: 'A venir',
+              label: context.l10n.upcoming,
               value: upcoming,
               color: const Color(0xFF34C759),
               icon: Icons.schedule_rounded,
@@ -175,7 +175,7 @@ class _AppointmentsScreenState extends State<AppointmentsScreen>
           const SizedBox(width: 10),
           Expanded(
             child: _SummaryCard(
-              label: 'Termines',
+              label: context.l10n.completed,
               value: completed,
               color: const Color(0xFF6366F1),
               icon: Icons.check_circle_rounded,
@@ -215,9 +215,9 @@ class _AppointmentsScreenState extends State<AppointmentsScreen>
             fontSize: 12,
           ),
           tabs: [
-            Tab(text: 'A venir ($upcoming)'),
-            Tab(text: 'Passes ($past)'),
-            Tab(text: 'Annules ($cancelled)'),
+            Tab(text: '${context.l10n.upcoming} ($upcoming)'),
+            Tab(text: '${context.l10n.past} ($past)'),
+            Tab(text: '${context.l10n.cancelled} ($cancelled)'),
           ],
         ),
       ),
@@ -260,10 +260,10 @@ class _AppointmentsScreenState extends State<AppointmentsScreen>
         ? DateFormat('EEEE d MMMM yyyy', 'fr_FR').format(parsedDate)
         : appointment.date;
     final formattedDate = _capitalize(dateLabel);
-    final doctorName = appointment.doctor?.name ?? 'Medecin';
+    final doctorName = appointment.doctor?.name ?? context.l10n.doctor;
     final specialty = appointment.doctor?.specialty ?? '';
     final address = appointment.doctor?.address ?? '';
-    final status = _statusMeta(appointment.status);
+    final status = _statusMeta(context, appointment.status);
 
     return Container(
       padding: const EdgeInsets.all(14),
@@ -449,7 +449,7 @@ class _AppointmentsScreenState extends State<AppointmentsScreen>
             TextButton.icon(
               onPressed: _reload,
               icon: const Icon(Icons.refresh_rounded, size: 16),
-              label: const Text('Reessayer'),
+              label: Text(context.l10n.retry),
             ),
           ],
         ),
@@ -457,32 +457,32 @@ class _AppointmentsScreenState extends State<AppointmentsScreen>
     );
   }
 
-  _StatusMeta _statusMeta(String raw) {
+  _StatusMeta _statusMeta(BuildContext context, String raw) {
     switch (raw.toUpperCase()) {
       case 'CONFIRMED':
-        return const _StatusMeta(
-          label: 'Confirme',
+        return _StatusMeta(
+          label: context.l10n.confirmed,
           textColor: Color(0xFF047857),
           bgColor: Color(0xFFD1FAE5),
           icon: Icons.verified_rounded,
         );
       case 'COMPLETED':
-        return const _StatusMeta(
-          label: 'Termine',
+        return _StatusMeta(
+          label: context.l10n.completed,
           textColor: Color(0xFF3730A3),
           bgColor: Color(0xFFE0E7FF),
           icon: Icons.check_circle_rounded,
         );
       case 'CANCELLED':
-        return const _StatusMeta(
-          label: 'Annule',
+        return _StatusMeta(
+          label: context.l10n.cancelled,
           textColor: Color(0xFFB42318),
           bgColor: Color(0xFFFEE4E2),
           icon: Icons.close_rounded,
         );
       default:
-        return const _StatusMeta(
-          label: 'En attente',
+        return _StatusMeta(
+          label: context.l10n.pending,
           textColor: Color(0xFFB45309),
           bgColor: Color(0xFFFEF3C7),
           icon: Icons.hourglass_top_rounded,

--- a/lib/features/booking/presentation/screens/booking_confirmation_screen.dart
+++ b/lib/features/booking/presentation/screens/booking_confirmation_screen.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 
 class BookingConfirmationScreen extends StatefulWidget {
   final String doctorId;
@@ -145,9 +146,9 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
               ),
             ),
           ),
-          const Text(
-            'Statut du rendez-vous',
-            style: TextStyle(
+          Text(
+            context.l10n.appointmentStatus,
+            style: const TextStyle(
               fontSize: 24,
               fontWeight: FontWeight.bold,
               color: Color(0xFF1D1D1F),
@@ -211,9 +212,9 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
       ),
       child: Column(
         children: [
-          const Text(
-            'Demande envoyée !',
-            style: TextStyle(
+          Text(
+            context.l10n.requestSent,
+            style: const TextStyle(
               fontSize: 24,
               fontWeight: FontWeight.bold,
               color: Color(0xFF1D1D1F),
@@ -238,9 +239,9 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
                   ),
                 ),
                 const SizedBox(width: 8),
-                const Text(
-                  'En attente de confirmation',
-                  style: TextStyle(
+                Text(
+                  context.l10n.waitingConfirmation,
+                  style: const TextStyle(
                     fontSize: 14,
                     fontWeight: FontWeight.w600,
                     color: Color(0xFFFF9500),
@@ -271,9 +272,9 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
-            'Détails du rendez-vous',
-            style: TextStyle(
+          Text(
+            context.l10n.appointmentDetails,
+            style: const TextStyle(
               fontSize: 18,
               fontWeight: FontWeight.w700,
               color: Color(0xFF1D1D1F),
@@ -354,19 +355,19 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
           // Date & Time
           _buildDetailRow(
             icon: LucideIcons.calendar,
-            label: 'Date',
+            label: context.l10n.dateLabel,
             value: DateFormat('EEEE d MMMM yyyy', 'fr_FR').format(widget.date),
           ),
           const SizedBox(height: 16),
           _buildDetailRow(
             icon: LucideIcons.clock3,
-            label: 'Heure',
+            label: context.l10n.timeLabel,
             value: widget.timeSlot,
           ),
           const SizedBox(height: 16),
           _buildDetailRow(
             icon: LucideIcons.mapPin,
-            label: 'Adresse',
+            label: context.l10n.addressLabel,
             value: widget.address,
           ),
         ],
@@ -451,9 +452,9 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const Text(
-                  'Et maintenant ?',
-                  style: TextStyle(
+                Text(
+                  context.l10n.andNow,
+                  style: const TextStyle(
                     fontSize: 15,
                     fontWeight: FontWeight.bold,
                     color: Color(0xFF1D1D1F),
@@ -461,7 +462,7 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
                 ),
                 const SizedBox(height: 6),
                 Text(
-                  'Vous recevrez une notification une fois que le médecin aura confirmé votre demande de rendez-vous.',
+                  context.l10n.youWillReceiveNotification,
                   style: TextStyle(
                     fontSize: 13,
                     color: Colors.grey.shade700,
@@ -517,8 +518,8 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
                 ),
                 SizedBox(width: 10),
                 Text(
-                  'Retour à l\'accueil',
-                  style: TextStyle(
+                  context.l10n.backToHome,
+                  style: const TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w700,
                     color: Colors.white,
@@ -548,8 +549,8 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
               ),
               SizedBox(width: 8),
               Text(
-                'Voir mes rendez-vous',
-                style: TextStyle(
+                context.l10n.seeMyAppointments,
+                style: const TextStyle(
                   fontSize: 15,
                   color: Color(0xFF34C759),
                   fontWeight: FontWeight.w600,

--- a/lib/features/booking/presentation/screens/booking_confirmation_screen.dart
+++ b/lib/features/booking/presentation/screens/booking_confirmation_screen.dart
@@ -508,7 +508,7 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
                 borderRadius: BorderRadius.circular(20),
               ),
             ),
-            child: const Row(
+            child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Icon(
@@ -539,7 +539,7 @@ class _BookingConfirmationScreenState extends State<BookingConfirmationScreen>
           style: TextButton.styleFrom(
             padding: const EdgeInsets.symmetric(vertical: 16),
           ),
-          child: const Row(
+          child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               Icon(

--- a/lib/features/booking/presentation/screens/booking_screen.dart
+++ b/lib/features/booking/presentation/screens/booking_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:provider/provider.dart';
 import '../providers/booking_provider.dart';
@@ -21,10 +22,10 @@ class BookingScreen extends StatefulWidget {
     String? imageUrl,
     String? address,
   })  : doctorId = doctorId ?? '',
-        doctorName = doctorName ?? 'Medecin',
-        specialty = specialty ?? 'Specialite',
+        doctorName = doctorName ?? '',
+        specialty = specialty ?? '',
         imageUrl = imageUrl ?? 'https://via.placeholder.com/150',
-        address = address ?? 'Adresse non renseignee';
+        address = address ?? '';
 
   @override
   State<BookingScreen> createState() => _BookingScreenState();
@@ -65,7 +66,7 @@ class _BookingScreenState extends State<BookingScreen> {
     if (_selectedTimeSlot == null) return;
     if (widget.doctorId.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Medecin invalide')),
+        SnackBar(content: Text(context.l10n.invalidDoctor)),
       );
       return;
     }
@@ -79,7 +80,7 @@ class _BookingScreenState extends State<BookingScreen> {
 
     if (appointment == null) {
       final err = context.read<BookingProvider>().error ??
-          'Erreur lors de la creation du rendez-vous';
+          context.l10n.createAppointmentFailed;
       ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(err)));
       return;
     }
@@ -209,15 +210,17 @@ class _BookingScreenState extends State<BookingScreen> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(widget.doctorName,
+                  Text(widget.doctorName.isNotEmpty ? widget.doctorName : context.l10n.doctor,
                       style: const TextStyle(
                           fontWeight: FontWeight.bold, fontSize: 16)),
                   const SizedBox(height: 2),
-                  Text(widget.specialty,
-                      style: TextStyle(color: Colors.grey.shade600, fontSize: 13)),
-                  const SizedBox(height: 2),
-                  Text(widget.address,
-                      style: TextStyle(color: Colors.grey.shade500, fontSize: 12)),
+                  if (widget.specialty.isNotEmpty)
+                    Text(widget.specialty,
+                        style: TextStyle(color: Colors.grey.shade600, fontSize: 13)),
+                  if (widget.specialty.isNotEmpty) const SizedBox(height: 2),
+                  if (widget.address.isNotEmpty)
+                    Text(widget.address,
+                        style: TextStyle(color: Colors.grey.shade500, fontSize: 12)),
                 ],
               ),
             ),
@@ -287,7 +290,7 @@ class _BookingScreenState extends State<BookingScreen> {
         if (provider.availableSlots.isEmpty) {
           return const Padding(
             padding: EdgeInsets.symmetric(horizontal: 20),
-            child: Text('Aucun creneau disponible pour cette date.'),
+            child: Text(context.l10n.noAvailableSlotsMessage),
           );
         }
         return Padding(
@@ -352,7 +355,7 @@ class _BookingScreenState extends State<BookingScreen> {
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               Text(
-                'Confirmer le rendez-vous',
+                context.l10n.confirmBooking,
                 style: TextStyle(
                   fontSize: 16,
                   fontWeight: FontWeight.w700,

--- a/lib/features/booking/presentation/screens/booking_screen.dart
+++ b/lib/features/booking/presentation/screens/booking_screen.dart
@@ -42,7 +42,6 @@ class _BookingScreenState extends State<BookingScreen> {
   @override
   void initState() {
     super.initState();
-    initializeDateFormatting('fr_FR', null);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadSlots();
     });
@@ -52,6 +51,11 @@ class _BookingScreenState extends State<BookingScreen> {
     final month = date.month.toString().padLeft(2, '0');
     final day = date.day.toString().padLeft(2, '0');
     return '${date.year}-$month-$day';
+  }
+
+  String _dateLocaleName(BuildContext context) {
+    final locale = Localizations.localeOf(context);
+    return locale.languageCode == 'fr' ? 'fr_FR' : 'en_US';
   }
 
   Future<void> _loadSlots() async {
@@ -166,7 +170,7 @@ class _BookingScreenState extends State<BookingScreen> {
             ),
           ),
           Text(
-            'Prendre rendez-vous',
+            context.l10n.bookAppointment,
             style: TextStyle(
               fontSize: 24,
               fontWeight: FontWeight.bold,
@@ -231,6 +235,7 @@ class _BookingScreenState extends State<BookingScreen> {
   }
 
   Widget _buildDateSelection() {
+    final localeName = _dateLocaleName(context);
     return SizedBox(
       height: 90,
       child: ListView.builder(
@@ -259,13 +264,13 @@ class _BookingScreenState extends State<BookingScreen> {
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Text(DateFormat('EEE', 'fr_FR').format(date),
+                  Text(DateFormat('EEE', localeName).format(date),
                       style: TextStyle(
                           fontSize: 12,
                           fontWeight: FontWeight.w600,
                           color: isSelected ? Colors.white : Colors.grey.shade600)),
                   const SizedBox(height: 8),
-                  Text(DateFormat('dd').format(date),
+                  Text(DateFormat('dd', localeName).format(date),
                       style: TextStyle(
                           fontSize: 20,
                           fontWeight: FontWeight.bold,

--- a/lib/features/booking/presentation/screens/booking_screen.dart
+++ b/lib/features/booking/presentation/screens/booking_screen.dart
@@ -165,7 +165,7 @@ class _BookingScreenState extends State<BookingScreen> {
                   size: 20, color: Color(0xFF1D1D1F)),
             ),
           ),
-          const Text(
+          Text(
             'Prendre rendez-vous',
             style: TextStyle(
               fontSize: 24,
@@ -288,7 +288,7 @@ class _BookingScreenState extends State<BookingScreen> {
           );
         }
         if (provider.availableSlots.isEmpty) {
-          return const Padding(
+          return Padding(
             padding: EdgeInsets.symmetric(horizontal: 20),
             child: Text(context.l10n.noAvailableSlotsMessage),
           );
@@ -351,7 +351,7 @@ class _BookingScreenState extends State<BookingScreen> {
             shadowColor: Colors.transparent,
             shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
           ),
-          child: const Row(
+          child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               Text(

--- a/lib/features/calendar/presentation/screens/calendar_screen.dart
+++ b/lib/features/calendar/presentation/screens/calendar_screen.dart
@@ -1,25 +1,28 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 import '../../../booking/presentation/providers/booking_provider.dart';
 
-class CalendarScreen extends StatefulWidget {
-  const CalendarScreen({super.key, this.initialTab = 'Programme'});
+enum CalendarTab { programme, list }
 
-  final String initialTab;
+class CalendarScreen extends StatefulWidget {
+  const CalendarScreen({super.key, this.initialTab = CalendarTab.programme});
+
+  final CalendarTab initialTab;
 
   @override
   State<CalendarScreen> createState() => _CalendarScreenState();
 }
 
 class _CalendarScreenState extends State<CalendarScreen> {
-  String _selectedTab = 'Programme';
+  CalendarTab _selectedTab = CalendarTab.programme;
   final TextEditingController _searchController = TextEditingController();
 
   @override
   void initState() {
     super.initState();
-    _selectedTab = _normalizeTab(widget.initialTab);
+    _selectedTab = widget.initialTab;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       context.read<BookingProvider>().loadDoctors();
     });
@@ -41,7 +44,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
             _buildHeader(),
             Expanded(
               child:
-                  _selectedTab == 'Programme' ? _buildSchedule() : _buildDoctors(),
+                  _selectedTab == CalendarTab.programme ? _buildSchedule() : _buildDoctors(),
             ),
           ],
         ),
@@ -75,8 +78,8 @@ class _CalendarScreenState extends State<CalendarScreen> {
                 ),
               ),
               const SizedBox(width: 12),
-              const Text(
-                'Calendrier',
+              Text(
+                context.l10n.calendar,
                 style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
             ],
@@ -92,20 +95,20 @@ class _CalendarScreenState extends State<CalendarScreen> {
               children: [
                 Expanded(
                   child: GestureDetector(
-                    onTap: () => setState(() => _selectedTab = 'Programme'),
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(vertical: 12),
-                      decoration: BoxDecoration(
-                        color: _selectedTab == 'Programme'
+                    onTap: () => setState(() => _selectedTab = CalendarTab.programme),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                    decoration: BoxDecoration(
+                        color: _selectedTab == CalendarTab.programme
                             ? Colors.white
                             : Colors.transparent,
                         borderRadius: BorderRadius.circular(12),
                       ),
                       child: Text(
-                        'Programme',
+                        context.l10n.schedule,
                         textAlign: TextAlign.center,
                         style: TextStyle(
-                          fontWeight: _selectedTab == 'Programme'
+                          fontWeight: _selectedTab == CalendarTab.programme
                               ? FontWeight.w700
                               : FontWeight.w500,
                         ),
@@ -115,19 +118,19 @@ class _CalendarScreenState extends State<CalendarScreen> {
                 ),
                 Expanded(
                   child: GestureDetector(
-                    onTap: () => setState(() => _selectedTab = 'Liste'),
+                    onTap: () => setState(() => _selectedTab = CalendarTab.list),
                     child: Container(
                       padding: const EdgeInsets.symmetric(vertical: 12),
                       decoration: BoxDecoration(
                         color:
-                            _selectedTab == 'Liste' ? Colors.white : Colors.transparent,
+                            _selectedTab == CalendarTab.list ? Colors.white : Colors.transparent,
                         borderRadius: BorderRadius.circular(12),
                       ),
                       child: Text(
-                        'Liste',
+                        context.l10n.lists,
                         textAlign: TextAlign.center,
                         style: TextStyle(
-                          fontWeight: _selectedTab == 'Liste'
+                          fontWeight: _selectedTab == CalendarTab.list
                               ? FontWeight.w700
                               : FontWeight.w500,
                         ),
@@ -144,9 +147,9 @@ class _CalendarScreenState extends State<CalendarScreen> {
   }
 
   Widget _buildSchedule() {
-    return const Center(
+    return Center(
       child: Text(
-        'Consultez la liste des medecins pour prendre rendez-vous.',
+        context.l10n.consultDoctorsToBook,
         textAlign: TextAlign.center,
       ),
     );
@@ -166,7 +169,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
                   provider.loadDoctors(search: value.trim().isEmpty ? null : value.trim());
                 },
                 decoration: InputDecoration(
-                  hintText: 'Rechercher un medecin...',
+                  hintText: context.l10n.searchDoctor,
                   filled: true,
                   fillColor: Colors.white,
                   border: OutlineInputBorder(
@@ -201,7 +204,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
                           ),
                         )
                   : doctors.isEmpty
-                      ? const Center(child: Text('Aucun medecin disponible'))
+                      ? Center(child: Text(context.l10n.noDoctorsAvailable))
                       : ListView.builder(
                           padding: const EdgeInsets.symmetric(horizontal: 16),
                           itemCount: doctors.length,
@@ -316,7 +319,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
             TextButton.icon(
               onPressed: onRetry,
               icon: const Icon(Icons.refresh_rounded, size: 16),
-              label: const Text('Reessayer'),
+              label: Text(context.l10n.retry),
             ),
           ],
         ),
@@ -324,9 +327,4 @@ class _CalendarScreenState extends State<CalendarScreen> {
     );
   }
 
-  String _normalizeTab(String tab) {
-    final value = tab.toLowerCase();
-    if (value == 'lists' || value == 'list') return 'Liste';
-    return 'Programme';
-  }
 }

--- a/lib/features/calendar/presentation/screens/calendar_screen.dart
+++ b/lib/features/calendar/presentation/screens/calendar_screen.dart
@@ -4,7 +4,7 @@ import 'package:provider/provider.dart';
 import '../../../booking/presentation/providers/booking_provider.dart';
 
 class CalendarScreen extends StatefulWidget {
-  const CalendarScreen({super.key, this.initialTab = 'Schedule'});
+  const CalendarScreen({super.key, this.initialTab = 'Programme'});
 
   final String initialTab;
 
@@ -13,7 +13,7 @@ class CalendarScreen extends StatefulWidget {
 }
 
 class _CalendarScreenState extends State<CalendarScreen> {
-  String _selectedTab = 'Schedule';
+  String _selectedTab = 'Programme';
   final TextEditingController _searchController = TextEditingController();
 
   @override
@@ -41,7 +41,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
             _buildHeader(),
             Expanded(
               child:
-                  _selectedTab == 'Schedule' ? _buildSchedule() : _buildDoctors(),
+                  _selectedTab == 'Programme' ? _buildSchedule() : _buildDoctors(),
             ),
           ],
         ),
@@ -76,7 +76,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
               ),
               const SizedBox(width: 12),
               const Text(
-                'Calendar',
+                'Calendrier',
                 style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
             ],
@@ -92,20 +92,20 @@ class _CalendarScreenState extends State<CalendarScreen> {
               children: [
                 Expanded(
                   child: GestureDetector(
-                    onTap: () => setState(() => _selectedTab = 'Schedule'),
+                    onTap: () => setState(() => _selectedTab = 'Programme'),
                     child: Container(
                       padding: const EdgeInsets.symmetric(vertical: 12),
                       decoration: BoxDecoration(
-                        color: _selectedTab == 'Schedule'
+                        color: _selectedTab == 'Programme'
                             ? Colors.white
                             : Colors.transparent,
                         borderRadius: BorderRadius.circular(12),
                       ),
                       child: Text(
-                        'Schedule',
+                        'Programme',
                         textAlign: TextAlign.center,
                         style: TextStyle(
-                          fontWeight: _selectedTab == 'Schedule'
+                          fontWeight: _selectedTab == 'Programme'
                               ? FontWeight.w700
                               : FontWeight.w500,
                         ),
@@ -115,19 +115,19 @@ class _CalendarScreenState extends State<CalendarScreen> {
                 ),
                 Expanded(
                   child: GestureDetector(
-                    onTap: () => setState(() => _selectedTab = 'Lists'),
+                    onTap: () => setState(() => _selectedTab = 'Liste'),
                     child: Container(
                       padding: const EdgeInsets.symmetric(vertical: 12),
                       decoration: BoxDecoration(
                         color:
-                            _selectedTab == 'Lists' ? Colors.white : Colors.transparent,
+                            _selectedTab == 'Liste' ? Colors.white : Colors.transparent,
                         borderRadius: BorderRadius.circular(12),
                       ),
                       child: Text(
-                        'Lists',
+                        'Liste',
                         textAlign: TextAlign.center,
                         style: TextStyle(
-                          fontWeight: _selectedTab == 'Lists'
+                          fontWeight: _selectedTab == 'Liste'
                               ? FontWeight.w700
                               : FontWeight.w500,
                         ),
@@ -326,7 +326,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
 
   String _normalizeTab(String tab) {
     final value = tab.toLowerCase();
-    if (value == 'lists' || value == 'list') return 'Lists';
-    return 'Schedule';
+    if (value == 'lists' || value == 'list') return 'Liste';
+    return 'Programme';
   }
 }

--- a/lib/features/chat/presentation/screens/chat_screen_ai.dart
+++ b/lib/features/chat/presentation/screens/chat_screen_ai.dart
@@ -13,8 +13,8 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 // Modèle pour les IAs spécialisées
 class AIDoctor {
   final String id;
-  final String name;
-  final String specialty;
+  final String Function(AppLocalizations l10n) nameBuilder;
+  final String Function(AppLocalizations l10n) specialtyBuilder;
   final Color primaryColor;
   final Color secondaryColor;
   final bool supported;
@@ -22,48 +22,51 @@ class AIDoctor {
 
   const AIDoctor({
     required this.id,
-    required this.name,
-    required this.specialty,
+    required this.nameBuilder,
+    required this.specialtyBuilder,
     required this.primaryColor,
     required this.secondaryColor,
     required this.supported,
     required this.ragAgentId,
   });
+
+  String name(AppLocalizations l10n) => nameBuilder(l10n);
+  String specialty(AppLocalizations l10n) => specialtyBuilder(l10n);
 }
 
 // Liste des IAs disponibles
 final List<AIDoctor> availableAIs = [
-  const AIDoctor(
+  AIDoctor(
     id: 'doc_locke',
-    name: 'Médecin généraliste',
-    specialty: 'Médecine Générale',
+    nameBuilder: (l10n) => l10n.generalPractitioner,
+    specialtyBuilder: (l10n) => l10n.generalMedicine,
     primaryColor: Color(0xFF34C759),
     secondaryColor: Color(0xFF5DF394),
     supported: true,
     ragAgentId: 'medecin_generaliste',
   ),
-  const AIDoctor(
+  AIDoctor(
     id: 'dr_dermato',
-    name: 'Dermatologue',
-    specialty: 'Dermatologie',
+    nameBuilder: (l10n) => l10n.dermatologist,
+    specialtyBuilder: (l10n) => l10n.dermatology,
     primaryColor: Color(0xFFFF9500),
     secondaryColor: Color(0xFFFFB340),
     supported: true,
     ragAgentId: 'dermatologue',
   ),
-  const AIDoctor(
+  AIDoctor(
     id: 'dr_nutrition',
-    name: 'Nutritionniste',
-    specialty: 'Nutrition',
+    nameBuilder: (l10n) => l10n.nutritionist,
+    specialtyBuilder: (l10n) => l10n.nutrition,
     primaryColor: Color(0xFF0EA5E9),
     secondaryColor: Color(0xFF38BDF8),
     supported: true,
     ragAgentId: 'nutritionniste',
   ),
-  const AIDoctor(
+  AIDoctor(
     id: 'dr_psy',
-    name: 'Psychologue',
-    specialty: 'Santé mentale',
+    nameBuilder: (l10n) => l10n.psychologist,
+    specialtyBuilder: (l10n) => l10n.mentalHealth,
     primaryColor: Color(0xFF8B5CF6),
     secondaryColor: Color(0xFFA78BFA),
     supported: true,
@@ -122,7 +125,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
     
     _assistant = chat_core.User(
       id: _currentAI.id,
-      name: _currentAI.name,
+      name: _currentAI.id,
     );
     
     _ragAgentId = _currentAI.ragAgentId ?? 'medecin_generaliste';
@@ -174,10 +177,12 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
     });
 
     if (initial.isEmpty && mounted) {
-      setState(() {
-        _addSystemMessage(
-          'Bonjour Georges ! Je suis ${_currentAI.name}, spécialiste en ${_currentAI.specialty}. '
-          'Comment puis-je vous aider aujourd\'hui ?',
+        setState(() {
+          _addSystemMessage(
+          context.l10n.aiDoctorGreeting(
+            _currentAI.name(context.l10n),
+            _currentAI.specialty(context.l10n),
+          ),
         );
       });
     }
@@ -259,8 +264,8 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                       children: [
                         const Icon(Icons.auto_awesome_rounded, color: Color(0xFF6C63FF), size: 28),
                         const SizedBox(width: 12),
-                        const Text(
-                          'Choisir un spécialiste',
+                        Text(
+                          context.l10n.chooseSpecialist,
                           style: TextStyle(
                             fontSize: 18,
                             fontWeight: FontWeight.bold,
@@ -323,7 +328,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                                     _currentAI = ai;
                                     _assistant = chat_core.User(
                                       id: _currentAI.id,
-                                      name: _currentAI.name,
+                                      name: _currentAI.id,
                                     );
                                     _ragAgentId = _currentAI.ragAgentId ?? 'medecin_generaliste';
                                     _isTyping = false;
@@ -366,7 +371,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                                         crossAxisAlignment: CrossAxisAlignment.start,
                                         children: [
                                           Text(
-                                            ai.name,
+                                            ai.name(context.l10n),
                                             style: const TextStyle(
                                               fontSize: 16,
                                               fontWeight: FontWeight.w600,
@@ -375,7 +380,9 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                                           ),
                                           const SizedBox(height: 4),
                                           Text(
-                                            ai.supported ? ai.specialty : '${ai.specialty} • ${context.l10n.soonAvailable}',
+                                            ai.supported
+                                                ? ai.specialty(context.l10n)
+                                                : '${ai.specialty(context.l10n)} • ${context.l10n.soonAvailable}',
                                             style: TextStyle(
                                               fontSize: 13,
                                               color: Colors.grey[600],
@@ -429,9 +436,9 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                           side: const BorderSide(color: Color(0xFF6C63FF), width: 1.5),
                         ),
                       ),
-                      child: const Text(
-                        'Fermer',
-                        style: TextStyle(
+                      child: Text(
+                        context.l10n.close,
+                        style: const TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w600,
                         ),
@@ -484,7 +491,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Text(
+                              Text(
                               'Georges',
                               style: TextStyle(
                                 color: Colors.white,
@@ -494,7 +501,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                             ),
                             SizedBox(height: 2),
                             Text(
-                              'Patient',
+                              context.l10n.patient,
                               style: TextStyle(
                                 color: Colors.white70,
                                 fontSize: 13,
@@ -538,7 +545,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                       Icon(Icons.auto_awesome_rounded, color: Colors.white, size: 20),
                       SizedBox(width: 8),
                       Text(
-                        'Choisir une spécialité',
+                        context.l10n.chooseSpecialty,
                         style: TextStyle(
                           color: Colors.white,
                           fontWeight: FontWeight.w600,
@@ -557,7 +564,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
               child: Row(
                 children: [
                   Text(
-                    'Spécialités',
+                    context.l10n.specialties,
                     style: TextStyle(
                       fontSize: 12,
                       fontWeight: FontWeight.w600,
@@ -587,7 +594,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                 ),
               ),
               title: Text(
-                ai.name,
+                ai.name(context.l10n),
                 style: TextStyle(
                   fontWeight: ai.id == _currentAI.id ? FontWeight.bold : FontWeight.w500,
                   fontSize: 14,
@@ -599,7 +606,9 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                 ),
               ),
               subtitle: Text(
-                ai.supported ? ai.specialty : '${ai.specialty} • ${context.l10n.soonAvailable}',
+                ai.supported
+                    ? ai.specialty(context.l10n)
+                    : '${ai.specialty(context.l10n)} • ${context.l10n.soonAvailable}',
                 style: TextStyle(
                   fontSize: 12,
                   color: Colors.grey.withValues(alpha:0.2),
@@ -867,8 +876,10 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
     if (mounted) {
       setState(() {
         _addSystemMessage(
-          'Bonjour Georges ! Je suis ${_currentAI.name}, spécialiste en ${_currentAI.specialty}. '
-          'Comment puis-je vous aider aujourd\'hui ?',
+          context.l10n.aiDoctorGreeting(
+            _currentAI.name(context.l10n),
+            _currentAI.specialty(context.l10n),
+          ),
         );
       });
     }
@@ -1007,7 +1018,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                     ),
                     const SizedBox(height: 4),
                     Text(
-                      doctor['specialty'] ?? 'Lung Specialist',
+                      doctor['specialty'] ?? context.l10n.lungSpecialist,
                       style: TextStyle(
                         fontSize: 13,
                         color: Colors.grey.withValues(alpha:0.2),
@@ -1067,7 +1078,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                 Icon(Icons.access_time, color: Colors.white, size: 18),
                 SizedBox(width: 8),
                 Text(
-                  '10:30 - 11:30 AM',
+                  context.l10n.doctorCardTimeSlot,
                   style: TextStyle(
                     color: Colors.white,
                     fontWeight: FontWeight.w600,
@@ -1080,7 +1091,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
           const SizedBox(height: 8),
           Center(
             child: Text(
-              'For a Lung Checkup',
+              context.l10n.lungCheckup,
               style: TextStyle(
                 fontSize: 12,
                 color: Colors.grey.withValues(alpha:0.2),
@@ -1144,7 +1155,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                     children: [
                       Flexible(
                         child: Text(
-                          _currentAI.name,
+                          _currentAI.name(context.l10n),
                           style: const TextStyle(
                             fontWeight: FontWeight.bold,
                             fontSize: 17,
@@ -1161,8 +1172,8 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                           color: const Color(0xFFF5F2C1),
                           borderRadius: BorderRadius.circular(8),
                         ),
-                        child: const Text(
-                          'PRO',
+                        child: Text(
+                          context.l10n.proMember.toUpperCase(),
                           style: TextStyle(
                             fontSize: 9,
                             fontWeight: FontWeight.bold,
@@ -1175,7 +1186,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                   ),
                   const SizedBox(height: 2),
                   Text(
-                    _currentAI.specialty,
+                    _currentAI.specialty(context.l10n),
                     style: TextStyle(
                       fontSize: 12,
                       color: Colors.grey.withValues(alpha:0.2),
@@ -1186,10 +1197,10 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                   const SizedBox(height: 2),
                   Text(
                     _isStreaming
-                        ? 'En train d\'écrire...'
+                        ? context.l10n.writingStatus
                         : _isConnected
-                            ? 'En ligne'
-                            : 'Connexion...',
+                            ? context.l10n.online
+                            : context.l10n.connecting,
                     style: TextStyle(
                       fontSize: 11,
                       color: _isStreaming
@@ -1274,8 +1285,8 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                             ),
                             child: const Icon(Icons.delete_outline_rounded, color: Colors.red, size: 22),
                           ),
-                          title: const Text(
-                            'Effacer l\'historique',
+                          title: Text(
+                            context.l10n.clearHistory,
                             style: TextStyle(fontWeight: FontWeight.w600),
                           ),
                           onTap: () {

--- a/lib/features/chat/presentation/screens/chat_screen_ai.dart
+++ b/lib/features/chat/presentation/screens/chat_screen_ai.dart
@@ -539,7 +539,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                       ),
                     ],
                   ),
-                  child: const Row(
+                  child: Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       Icon(Icons.auto_awesome_rounded, color: Colors.white, size: 20),
@@ -1072,7 +1072,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
               color: _currentAI.primaryColor,
               borderRadius: BorderRadius.circular(12),
             ),
-            child: const Row(
+            child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Icon(Icons.access_time, color: Colors.white, size: 18),

--- a/lib/features/chat/presentation/screens/chat_screen_ai.dart
+++ b/lib/features/chat/presentation/screens/chat_screen_ai.dart
@@ -487,11 +487,11 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                         ),
                       ),
                       const SizedBox(width: 12),
-                      const Expanded(
+                      Expanded(
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                              Text(
+                            const Text(
                               'Georges',
                               style: TextStyle(
                                 color: Colors.white,
@@ -499,7 +499,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                                 fontWeight: FontWeight.bold,
                               ),
                             ),
-                            SizedBox(height: 2),
+                            const SizedBox(height: 2),
                             Text(
                               context.l10n.patient,
                               style: TextStyle(

--- a/lib/features/chat/presentation/screens/chat_screen_ai.dart
+++ b/lib/features/chat/presentation/screens/chat_screen_ai.dart
@@ -1090,7 +1090,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                 Icon(Icons.access_time, color: Colors.white, size: 18),
                 SizedBox(width: 8),
                 Text(
-                  context.l10n.doctorCardTimeSlot,
+                  '10:30 - 11:30',
                   style: TextStyle(
                     color: Colors.white,
                     fontWeight: FontWeight.w600,

--- a/lib/features/chat/presentation/screens/chat_screen_ai.dart
+++ b/lib/features/chat/presentation/screens/chat_screen_ai.dart
@@ -4,11 +4,13 @@ import 'package:corevia_mobile/features/ai_chat/data/rag_chat_storage.dart';
 import 'package:corevia_mobile/features/ai_chat/data/rag_socket_chat_service.dart';
 import 'package:corevia_mobile/features/ai_chat/data/rag_socket_config.dart';
 import 'package:corevia_mobile/features/ai_chat/domain/chat_message.dart' as rag;
+import 'package:corevia_mobile/features/account/presentation/providers/user_provider.dart';
 import 'package:corevia_mobile/l10n/app_localizations.dart';
 import 'package:corevia_mobile/widgets/navigation_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_core/flutter_chat_core.dart' as chat_core;
 import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:provider/provider.dart';
 
 // Modèle pour les IAs spécialisées
 class AIDoctor {
@@ -93,7 +95,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
   late chat_core.User _assistant;
   final chat_core.User _currentUser = const chat_core.User(
     id: 'user',
-    name: 'Georges',
+    name: 'Patient',
   );
   chat_core.InMemoryChatController? _chatController;
   bool _isTyping = false;
@@ -109,6 +111,14 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
   final TextEditingController _messageController = TextEditingController();
   final FocusNode _messageFocusNode = FocusNode();
   late AnimationController _typingAnimationController;
+
+  String _patientName(BuildContext context) {
+    final userName = context.read<UserProvider>().user?.name.trim();
+    if (userName != null && userName.isNotEmpty) {
+      return userName;
+    }
+    return context.l10n.patient;
+  }
 
   @override
   void initState() {
@@ -179,11 +189,12 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
     if (initial.isEmpty && mounted) {
         setState(() {
           _addSystemMessage(
-          context.l10n.aiDoctorGreeting(
-            _currentAI.name(context.l10n),
-            _currentAI.specialty(context.l10n),
-          ),
-        );
+            context.l10n.aiDoctorGreeting(
+              _patientName(context),
+              _currentAI.name(context.l10n),
+              _currentAI.specialty(context.l10n),
+            ),
+          );
       });
     }
   }
@@ -491,8 +502,8 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            const Text(
-                              'Georges',
+                            Text(
+                              _patientName(context),
                               style: TextStyle(
                                 color: Colors.white,
                                 fontSize: 18,
@@ -877,6 +888,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
       setState(() {
         _addSystemMessage(
           context.l10n.aiDoctorGreeting(
+            _patientName(context),
             _currentAI.name(context.l10n),
             _currentAI.specialty(context.l10n),
           ),

--- a/lib/features/chat/presentation/screens/chat_screen_ai.dart
+++ b/lib/features/chat/presentation/screens/chat_screen_ai.dart
@@ -4,6 +4,7 @@ import 'package:corevia_mobile/features/ai_chat/data/rag_chat_storage.dart';
 import 'package:corevia_mobile/features/ai_chat/data/rag_socket_chat_service.dart';
 import 'package:corevia_mobile/features/ai_chat/data/rag_socket_config.dart';
 import 'package:corevia_mobile/features/ai_chat/domain/chat_message.dart' as rag;
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 import 'package:corevia_mobile/widgets/navigation_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_core/flutter_chat_core.dart' as chat_core;
@@ -139,9 +140,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
       if (!mounted) return;
       if (!requestedAI.supported && !_warnedUnsupportedAi) {
         _warnedUnsupportedAi = true;
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Specialite bientot disponible.')),
-        );
+        _showSoonSnackBar();
       }
     });
   }
@@ -376,7 +375,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                                           ),
                                           const SizedBox(height: 4),
                                           Text(
-                                            ai.supported ? ai.specialty : '${ai.specialty} • Bientôt disponible',
+                                            ai.supported ? ai.specialty : '${ai.specialty} • ${context.l10n.soonAvailable}',
                                             style: TextStyle(
                                               fontSize: 13,
                                               color: Colors.grey[600],
@@ -600,7 +599,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                 ),
               ),
               subtitle: Text(
-                ai.supported ? ai.specialty : '${ai.specialty} • Bientôt disponible',
+                ai.supported ? ai.specialty : '${ai.specialty} • ${context.l10n.soonAvailable}',
                 style: TextStyle(
                   fontSize: 12,
                   color: Colors.grey.withValues(alpha:0.2),
@@ -673,7 +672,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                 textInputAction: TextInputAction.send,
                 onSubmitted: (supported && !_isStreaming) ? (_) => _sendCurrentMessage() : null,
                 decoration: InputDecoration(
-                  hintText: supported ? 'Tapez un message...' : 'Bientôt disponible...',
+                  hintText: supported ? context.l10n.writeMessage : context.l10n.soonAvailable,
                   hintStyle: TextStyle(
                     color: Colors.grey.withValues(alpha:0.2), 
                     fontSize: 15,
@@ -843,7 +842,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
   void _showSoonSnackBar() {
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Spécialité bientôt disponible.')),
+      SnackBar(content: Text(context.l10n.soonAvailable)),
     );
   }
 

--- a/lib/features/chat/presentation/screens/chat_screen_ai.dart
+++ b/lib/features/chat/presentation/screens/chat_screen_ai.dart
@@ -140,7 +140,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
       if (!requestedAI.supported && !_warnedUnsupportedAi) {
         _warnedUnsupportedAi = true;
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Spécialité bientôt disponible.')),
+          const SnackBar(content: Text('Specialite bientot disponible.')),
         );
       }
     });
@@ -673,7 +673,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                 textInputAction: TextInputAction.send,
                 onSubmitted: (supported && !_isStreaming) ? (_) => _sendCurrentMessage() : null,
                 decoration: InputDecoration(
-                  hintText: supported ? 'Type a message...' : 'Bientôt disponible...',
+                  hintText: supported ? 'Tapez un message...' : 'Bientôt disponible...',
                   hintStyle: TextStyle(
                     color: Colors.grey.withValues(alpha:0.2), 
                     fontSize: 15,

--- a/lib/features/chat/presentation/screens/conversations_list_screen.dart
+++ b/lib/features/chat/presentation/screens/conversations_list_screen.dart
@@ -56,7 +56,7 @@ class _ConversationsListScreenState extends State<ConversationsListScreen> {
     } else if (difference.inDays == 1) {
       return context.l10n.yesterday;
     } else {
-      return context.l10n.formattedDate(DateFormat('dd/MM').format(time));
+      return DateFormat('dd/MM').format(time);
     }
   }
 

--- a/lib/features/chat/presentation/screens/conversations_list_screen.dart
+++ b/lib/features/chat/presentation/screens/conversations_list_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import '../../../../../l10n/app_localizations.dart';
 import 'chat_screen_ai.dart';
 import '../../../../../widgets/navigation_bar.dart';
 
@@ -90,8 +91,8 @@ class _ConversationsListScreenState extends State<ConversationsListScreen> {
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
-                      const Text(
-                        'Messages',
+                      Text(
+                        context.l10n.messages,
                         style: TextStyle(
                           fontSize: 32,
                           fontWeight: FontWeight.bold,

--- a/lib/features/chat/presentation/screens/conversations_list_screen.dart
+++ b/lib/features/chat/presentation/screens/conversations_list_screen.dart
@@ -12,12 +12,12 @@ class ConversationsListScreen extends StatefulWidget {
 }
 
 class _ConversationsListScreenState extends State<ConversationsListScreen> {
-  final List<Map<String, dynamic>> _conversations = [
+  List<Map<String, dynamic>> _conversations(BuildContext context) => [
     {
       'id': '1',
       'title': 'Dr. Ahmed Badaoui',
-      'specialty': 'Spécialiste des poumons',
-      'lastMessage': 'Votre rendez-vous est confirmé pour demain à 10h30',
+      'specialty': context.l10n.lungSpecialist,
+      'lastMessage': context.l10n.appointmentConfirmedTomorrowAt1030,
       'time': DateTime.now().subtract(const Duration(minutes: 30)),
       'unread': 2,
       'avatar': 'https://i.pravatar.cc/150?img=12',
@@ -26,8 +26,8 @@ class _ConversationsListScreenState extends State<ConversationsListScreen> {
     {
       'id': '2',
       'title': 'Dr. Sarah Johnson',
-      'specialty': 'Médecin généraliste',
-      'lastMessage': 'N\'oubliez pas de prendre votre médicament ce matin',
+      'specialty': context.l10n.generalPractitioner,
+      'lastMessage': context.l10n.takeMedicationThisMorning,
       'time': DateTime.now().subtract(const Duration(hours: 2)),
       'unread': 0,
       'avatar': 'https://i.pravatar.cc/150?img=45',
@@ -36,8 +36,8 @@ class _ConversationsListScreenState extends State<ConversationsListScreen> {
     {
       'id': '3',
       'title': 'Dr. Paul Martin',
-      'specialty': 'Cardiologue',
-      'lastMessage': 'Vos résultats d\'examen sont disponibles',
+      'specialty': context.l10n.doctor,
+      'lastMessage': context.l10n.examResultsAvailable,
       'time': DateTime.now().subtract(const Duration(days: 1)),
       'unread': 0,
       'avatar': 'https://i.pravatar.cc/150?img=33',
@@ -132,7 +132,7 @@ class _ConversationsListScreenState extends State<ConversationsListScreen> {
                         Icon(Icons.search, color: Colors.grey[600], size: 20),
                         const SizedBox(width: 10),
                         Text(
-                          'Rechercher des conversations...',
+                          context.l10n.searchConversations,
                           style: TextStyle(
                             fontSize: 15,
                             color: Colors.grey[600],
@@ -148,9 +148,9 @@ class _ConversationsListScreenState extends State<ConversationsListScreen> {
             Expanded(
               child: ListView.builder(
                 padding: const EdgeInsets.symmetric(vertical: 10),
-                itemCount: _conversations.length,
+                itemCount: _conversations(context).length,
                 itemBuilder: (context, index) {
-                  final conversation = _conversations[index];
+                  final conversation = _conversations(context)[index];
                   return _buildConversationCard(conversation);
                 },
               ),

--- a/lib/features/chat/presentation/screens/conversations_list_screen.dart
+++ b/lib/features/chat/presentation/screens/conversations_list_screen.dart
@@ -15,8 +15,8 @@ class _ConversationsListScreenState extends State<ConversationsListScreen> {
     {
       'id': '1',
       'title': 'Dr. Ahmed Badaoui',
-      'specialty': 'Lung Specialist',
-      'lastMessage': 'Your appointment is confirmed for tomorrow at 10:30 AM',
+      'specialty': 'Specialiste des poumons',
+      'lastMessage': 'Votre rendez-vous est confirme pour demain a 10h30',
       'time': DateTime.now().subtract(const Duration(minutes: 30)),
       'unread': 2,
       'avatar': 'https://i.pravatar.cc/150?img=12',
@@ -25,8 +25,8 @@ class _ConversationsListScreenState extends State<ConversationsListScreen> {
     {
       'id': '2',
       'title': 'Dr. Sarah Johnson',
-      'specialty': 'General Practitioner',
-      'lastMessage': 'Don\'t forget to take your medication this morning',
+      'specialty': 'Medecin generaliste',
+      'lastMessage': 'N\'oubliez pas de prendre votre medicament ce matin',
       'time': DateTime.now().subtract(const Duration(hours: 2)),
       'unread': 0,
       'avatar': 'https://i.pravatar.cc/150?img=45',
@@ -35,8 +35,8 @@ class _ConversationsListScreenState extends State<ConversationsListScreen> {
     {
       'id': '3',
       'title': 'Dr. Paul Martin',
-      'specialty': 'Cardiologist',
-      'lastMessage': 'Your test results are available',
+      'specialty': 'Cardiologue',
+      'lastMessage': 'Vos resultats d\'examen sont disponibles',
       'time': DateTime.now().subtract(const Duration(days: 1)),
       'unread': 0,
       'avatar': 'https://i.pravatar.cc/150?img=33',
@@ -49,11 +49,11 @@ class _ConversationsListScreenState extends State<ConversationsListScreen> {
     final difference = now.difference(time);
 
     if (difference.inMinutes < 60) {
-      return '${difference.inMinutes}m ago';
+      return 'Il y a ${difference.inMinutes} min';
     } else if (difference.inHours < 24) {
-      return '${difference.inHours}h ago';
+      return 'Il y a ${difference.inHours} h';
     } else if (difference.inDays == 1) {
-      return 'Yesterday';
+      return 'Hier';
     } else {
       return DateFormat('dd/MM').format(time);
     }
@@ -131,7 +131,7 @@ class _ConversationsListScreenState extends State<ConversationsListScreen> {
                         Icon(Icons.search, color: Colors.grey[600], size: 20),
                         const SizedBox(width: 10),
                         Text(
-                          'Search conversations...',
+                          'Rechercher des conversations...',
                           style: TextStyle(
                             fontSize: 15,
                             color: Colors.grey[600],

--- a/lib/features/chat/presentation/screens/conversations_list_screen.dart
+++ b/lib/features/chat/presentation/screens/conversations_list_screen.dart
@@ -16,8 +16,8 @@ class _ConversationsListScreenState extends State<ConversationsListScreen> {
     {
       'id': '1',
       'title': 'Dr. Ahmed Badaoui',
-      'specialty': 'Specialiste des poumons',
-      'lastMessage': 'Votre rendez-vous est confirme pour demain a 10h30',
+      'specialty': 'Spécialiste des poumons',
+      'lastMessage': 'Votre rendez-vous est confirmé pour demain à 10h30',
       'time': DateTime.now().subtract(const Duration(minutes: 30)),
       'unread': 2,
       'avatar': 'https://i.pravatar.cc/150?img=12',
@@ -26,8 +26,8 @@ class _ConversationsListScreenState extends State<ConversationsListScreen> {
     {
       'id': '2',
       'title': 'Dr. Sarah Johnson',
-      'specialty': 'Medecin generaliste',
-      'lastMessage': 'N\'oubliez pas de prendre votre medicament ce matin',
+      'specialty': 'Médecin généraliste',
+      'lastMessage': 'N\'oubliez pas de prendre votre médicament ce matin',
       'time': DateTime.now().subtract(const Duration(hours: 2)),
       'unread': 0,
       'avatar': 'https://i.pravatar.cc/150?img=45',
@@ -37,7 +37,7 @@ class _ConversationsListScreenState extends State<ConversationsListScreen> {
       'id': '3',
       'title': 'Dr. Paul Martin',
       'specialty': 'Cardiologue',
-      'lastMessage': 'Vos resultats d\'examen sont disponibles',
+      'lastMessage': 'Vos résultats d\'examen sont disponibles',
       'time': DateTime.now().subtract(const Duration(days: 1)),
       'unread': 0,
       'avatar': 'https://i.pravatar.cc/150?img=33',
@@ -45,18 +45,18 @@ class _ConversationsListScreenState extends State<ConversationsListScreen> {
     },
   ];
 
-  String _formatTime(DateTime time) {
+  String _formatTime(BuildContext context, DateTime time) {
     final now = DateTime.now();
     final difference = now.difference(time);
 
     if (difference.inMinutes < 60) {
-      return 'Il y a ${difference.inMinutes} min';
+      return context.l10n.minutesAgo(difference.inMinutes);
     } else if (difference.inHours < 24) {
-      return 'Il y a ${difference.inHours} h';
+      return context.l10n.hoursAgo(difference.inHours);
     } else if (difference.inDays == 1) {
-      return 'Hier';
+      return context.l10n.yesterday;
     } else {
-      return DateFormat('dd/MM').format(time);
+      return context.l10n.formattedDate(DateFormat('dd/MM').format(time));
     }
   }
 
@@ -251,7 +251,7 @@ class _ConversationsListScreenState extends State<ConversationsListScreen> {
                             ),
                           ),
                           Text(
-                            _formatTime(conversation['time']),
+                            _formatTime(context, conversation['time']),
                             style: TextStyle(
                               fontSize: 12,
                               color: Colors.grey[600],

--- a/lib/features/documents/presentation/screens/documents_screen.dart
+++ b/lib/features/documents/presentation/screens/documents_screen.dart
@@ -9,6 +9,7 @@ import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:corevia_mobile/core/theme/colors.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 import '../providers/document_provider.dart';
 import '../../domain/entities/document_entity.dart';
 
@@ -108,7 +109,7 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
               if (!mounted) return;
               setState(() {
                 _uploads[file.id]?.status = _UploadStatus.error;
-                _uploads[file.id]?.error = 'Confirm failed';
+                _uploads[file.id]?.error = 'Echec de la confirmation';
               });
               _checkAllDone();
             });
@@ -119,7 +120,7 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
             _uploads[file.id]?.error = message;
           });
           ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Upload failed: $message')),
+            SnackBar(content: Text(context.l10n.uploadFailed(message))),
           );
           _checkAllDone();
         default:
@@ -140,7 +141,7 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
       final successCount = _uploads.values.where((e) => e.status == _UploadStatus.confirmed).length;
       if (successCount > 0 && mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('$successCount file(s) uploaded')),
+          SnackBar(content: Text(context.l10n.filesUploaded(successCount))),
         );
       }
     }
@@ -161,7 +162,7 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
       if (pf.size > _maxFileSize) {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('${pf.name} exceeds 25 MB limit')),
+            SnackBar(content: Text(context.l10n.fileTooLarge(pf.name))),
           );
         }
         continue;
@@ -192,7 +193,7 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to download: $e')),
+          SnackBar(content: Text(context.l10n.failedToDownload(e.toString()))),
         );
       }
     }
@@ -206,16 +207,19 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
       context: context,
       useRootNavigator: true,
       builder: (ctx) => AlertDialog(
-        title: const Text('Delete Document'),
-        content: Text('Delete "${doc.fileName}"? This action cannot be undone.'),
+        title: Text(context.l10n.deleteDocumentTitle),
+        content: Text(context.l10n.deleteDocumentConfirm(doc.fileName)),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(ctx, rootNavigator: true).pop(false),
-            child: const Text('Cancel'),
+            child: Text(context.l10n.cancel),
           ),
           TextButton(
             onPressed: () => Navigator.of(ctx, rootNavigator: true).pop(true),
-            child: const Text('Delete', style: TextStyle(color: Colors.red)),
+            child: Text(
+              context.l10n.delete,
+              style: const TextStyle(color: Colors.red),
+            ),
           ),
         ],
       ),
@@ -225,13 +229,13 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
       await provider.deleteDocument(doc.id);
       if (mounted) {
         messenger.showSnackBar(
-          const SnackBar(content: Text('Document deleted')),
+          SnackBar(content: Text(context.l10n.documentDeleted)),
         );
       }
     } catch (e) {
       if (mounted) {
         messenger.showSnackBar(
-          SnackBar(content: Text('Failed to delete: $e')),
+          SnackBar(content: Text(context.l10n.failedToDelete(e.toString()))),
         );
       }
     }
@@ -303,9 +307,9 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
             padding: EdgeInsets.zero,
           ),
           const SizedBox(width: 8),
-          const Text(
-            'My Documents',
-            style: TextStyle(
+          Text(
+            context.l10n.myDocuments,
+            style: const TextStyle(
               fontSize: 28,
               fontWeight: FontWeight.bold,
               color: Color(0xFF1D1D1F),
@@ -340,7 +344,7 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
             ),
             const SizedBox(width: 12),
             Text(
-              _isUploading ? 'Uploading...' : 'Upload Documents',
+              _isUploading ? context.l10n.uploading : context.l10n.uploadDocuments,
               style: TextStyle(
                 fontSize: 16,
                 fontWeight: FontWeight.w600,
@@ -375,7 +379,7 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 const Text(
-                  'Uploading',
+                  'Televersement',
                   style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
                 ),
                 Text(
@@ -492,7 +496,7 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
             Icon(LucideIcons.fileText, size: 48, color: Colors.grey.shade300),
             const SizedBox(height: 16),
             Text(
-              'No documents yet',
+              context.l10n.noDocumentsYet,
               style: TextStyle(
                 fontSize: 16,
                 fontWeight: FontWeight.w600,
@@ -501,7 +505,7 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
             ),
             const SizedBox(height: 8),
             Text(
-              'Upload your first document to get started',
+              context.l10n.uploadFirstDocument,
               style: TextStyle(fontSize: 14, color: Colors.grey.shade400),
             ),
           ],
@@ -524,10 +528,10 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Padding(
+          Padding(
             padding: EdgeInsets.fromLTRB(20, 20, 20, 8),
             child: Text(
-              'Your Documents',
+              context.l10n.yourDocuments,
               style: TextStyle(
                 fontSize: 18,
                 fontWeight: FontWeight.w700,

--- a/lib/features/documents/presentation/screens/documents_screen.dart
+++ b/lib/features/documents/presentation/screens/documents_screen.dart
@@ -67,7 +67,9 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
             return UploadParameters(
               method: 'PUT',
               url: result['uploadUrl']!,
-              headers: {'Content-Type': file.type ?? 'application/octet-stream'},
+              headers: {
+                'Content-Type': file.type ?? 'application/octet-stream'
+              },
             );
           },
           createMultipartUpload: (_) async =>
@@ -109,7 +111,8 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
               if (!mounted) return;
               setState(() {
                 _uploads[file.id]?.status = _UploadStatus.error;
-                _uploads[file.id]?.error = 'Echec de la confirmation';
+                _uploads[file.id]?.error =
+                    context.l10n.confirmUploadFailed(e.toString());
               });
               _checkAllDone();
             });
@@ -134,11 +137,15 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
 
   void _checkAllDone() {
     final allTerminal = _uploads.values.every(
-      (e) => e.status == _UploadStatus.confirmed || e.status == _UploadStatus.error,
+      (e) =>
+          e.status == _UploadStatus.confirmed ||
+          e.status == _UploadStatus.error,
     );
     if (allTerminal && _isUploading) {
       setState(() => _isUploading = false);
-      final successCount = _uploads.values.where((e) => e.status == _UploadStatus.confirmed).length;
+      final successCount = _uploads.values
+          .where((e) => e.status == _UploadStatus.confirmed)
+          .length;
       if (successCount > 0 && mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(context.l10n.filesUploaded(successCount))),
@@ -326,10 +333,14 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
       child: Container(
         padding: const EdgeInsets.all(20),
         decoration: BoxDecoration(
-          color: _isUploading ? Colors.grey.shade100 : AppColors.green.withValues(alpha: 0.1),
+          color: _isUploading
+              ? Colors.grey.shade100
+              : AppColors.green.withValues(alpha: 0.1),
           borderRadius: BorderRadius.circular(20),
           border: Border.all(
-            color: _isUploading ? Colors.grey.shade300 : AppColors.green.withValues(alpha: 0.3),
+            color: _isUploading
+                ? Colors.grey.shade300
+                : AppColors.green.withValues(alpha: 0.3),
             width: 1.5,
             strokeAlign: BorderSide.strokeAlignInside,
           ),
@@ -344,7 +355,9 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
             ),
             const SizedBox(width: 12),
             Text(
-              _isUploading ? context.l10n.uploading : context.l10n.uploadDocuments,
+              _isUploading
+                  ? context.l10n.uploading
+                  : context.l10n.uploadDocuments,
               style: TextStyle(
                 fontSize: 16,
                 fontWeight: FontWeight.w600,
@@ -378,9 +391,10 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                const Text(
-                  'Televersement',
-                  style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+                Text(
+                  context.l10n.uploadingTitle,
+                  style: const TextStyle(
+                      fontSize: 14, fontWeight: FontWeight.w600),
                 ),
                 Text(
                   '${(_overallProgress * 100).round()}%',
@@ -398,13 +412,15 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
               child: LinearProgressIndicator(
                 value: _overallProgress,
                 backgroundColor: Colors.grey.shade200,
-                valueColor: const AlwaysStoppedAnimation<Color>(AppColors.green),
+                valueColor:
+                    const AlwaysStoppedAnimation<Color>(AppColors.green),
                 minHeight: 6,
               ),
             ),
             const SizedBox(height: 12),
           ],
-          ..._uploads.entries.map((entry) => _buildUploadItem(entry.key, entry.value)),
+          ..._uploads.entries
+              .map((entry) => _buildUploadItem(entry.key, entry.value)),
         ],
       ),
     );
@@ -441,7 +457,8 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
               children: [
                 Text(
                   entry.name,
-                  style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
+                  style: const TextStyle(
+                      fontSize: 14, fontWeight: FontWeight.w500),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                 ),
@@ -453,7 +470,8 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
                       child: LinearProgressIndicator(
                         value: entry.progress,
                         backgroundColor: Colors.grey.shade200,
-                        valueColor: const AlwaysStoppedAnimation<Color>(Colors.blue),
+                        valueColor:
+                            const AlwaysStoppedAnimation<Color>(Colors.blue),
                         minHeight: 3,
                       ),
                     ),
@@ -559,7 +577,8 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
                 color: const Color(0xFFF5F5F7),
                 borderRadius: BorderRadius.circular(12),
               ),
-              child: Icon(_mimeIcon(doc.mimeType), color: AppColors.green, size: 22),
+              child: Icon(_mimeIcon(doc.mimeType),
+                  color: AppColors.green, size: 22),
             ),
             const SizedBox(width: 16),
             Expanded(
@@ -585,7 +604,8 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
               ),
             ),
             IconButton(
-              icon: Icon(LucideIcons.trash2, size: 18, color: Colors.red.shade300),
+              icon: Icon(LucideIcons.trash2,
+                  size: 18, color: Colors.red.shade300),
               onPressed: () => _deleteDocument(doc),
               padding: EdgeInsets.zero,
               constraints: const BoxConstraints(minWidth: 36, minHeight: 36),

--- a/lib/features/documents/presentation/screens/documents_screen.dart
+++ b/lib/features/documents/presentation/screens/documents_screen.dart
@@ -112,18 +112,21 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
               setState(() {
                 _uploads[file.id]?.status = _UploadStatus.error;
                 _uploads[file.id]?.error =
-                    context.l10n.confirmUploadFailed(e.toString());
+                    context.l10n.confirmUploadFailed(
+                      _localizedUploadError(context, e.toString()),
+                    );
               });
               _checkAllDone();
             });
           }
         case UploadError(:final file, :final message):
+          final localizedMessage = _localizedUploadError(context, message);
           setState(() {
             _uploads[file.id]?.status = _UploadStatus.error;
-            _uploads[file.id]?.error = message;
+            _uploads[file.id]?.error = localizedMessage;
           });
           ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(context.l10n.uploadFailed(message))),
+            SnackBar(content: Text(localizedMessage)),
           );
           _checkAllDone();
         default:
@@ -152,6 +155,23 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
         );
       }
     }
+  }
+
+  String _localizedUploadError(BuildContext context, String message) {
+    final lower = message.toLowerCase();
+    if (lower.contains('too large') ||
+        lower.contains('file size') ||
+        lower.contains('larger than') ||
+        lower.contains('size limit')) {
+      return context.l10n.uploadFailedFileTooLarge;
+    }
+    if (lower.contains('network') ||
+        lower.contains('socket') ||
+        lower.contains('timeout') ||
+        lower.contains('connection')) {
+      return context.l10n.uploadFailedNetwork;
+    }
+    return message;
   }
 
   Future<void> _pickAndUpload() async {

--- a/lib/features/home/data/repositories/home_repository_impl.dart
+++ b/lib/features/home/data/repositories/home_repository_impl.dart
@@ -11,16 +11,16 @@ class HomeRepositoryImpl implements HomeRepository {
     try {
       final meResponse = await ApiService.authGet(UserRoutes.me());
       if (meResponse is! Map<String, dynamic>) {
-        throw Exception('Format de reponse invalide');
+        throw Exception('Invalid response format');
       }
 
       final user = _asMap(meResponse['user'] ?? meResponse);
       final stats = _asMap(meResponse['stats']);
 
       return HomeData(
-        title: 'Bienvenue sur CoreVia',
-        description: 'Votre application de gestion CoreVia',
-        userName: (user['name'] ?? 'Utilisateur').toString(),
+        title: 'Welcome to CoreVia',
+        description: 'Your CoreVia management app',
+        userName: (user['name'] ?? 'User').toString(),
         userImage: user['image']?.toString(),
         alertsCount: _asInt(meResponse['alertsCount']),
         appointmentsThisMonth: _asInt(stats['appointmentsThisMonth']),
@@ -31,9 +31,9 @@ class HomeRepositoryImpl implements HomeRepository {
     } catch (e) {
       debugPrint('HomeRepositoryImpl.getHomeData error: $e');
       return const HomeData(
-        title: 'Bienvenue sur CoreVia',
-        description: 'Votre application de gestion CoreVia',
-        userName: 'Utilisateur',
+        title: 'Welcome to CoreVia',
+        description: 'Your CoreVia management app',
+        userName: 'User',
         userImage: null,
         alertsCount: 0,
         appointmentsThisMonth: 0,

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 
 import '../../../../networking/api_service.dart';
 import '../../../../networking/routes/user_routes.dart';
@@ -140,7 +141,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      _name.isNotEmpty ? 'Hello, $_name' : 'Hello',
+                      _name.isNotEmpty ? context.l10n.helloUser(_name) : context.l10n.tr(fr: 'Bonjour', en: 'Hello'),
                       style: const TextStyle(
                         fontSize: 28,
                         fontWeight: FontWeight.bold,
@@ -161,7 +162,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                           Icon(Icons.star, size: 16, color: Color(0xFFFFBE0A)),
                           SizedBox(width: 4),
                           Text(
-                            'Pro member',
+                            'Membre Pro',
                             style: TextStyle(
                               fontSize: 13,
                               fontWeight: FontWeight.w700,
@@ -190,7 +191,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                   Icon(Icons.search, color: Colors.grey[600], size: 20),
                   const SizedBox(width: 12),
                   Text(
-                    'Start a chat with DocAI',
+                    'Commencer un chat avec DocAI',
                     style: TextStyle(fontSize: 16, color: Colors.grey[600]),
                   ),
                 ],

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -141,7 +141,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      _name.isNotEmpty ? context.l10n.helloUser(_name) : context.l10n.tr(fr: 'Bonjour', en: 'Hello'),
+                      _name.isNotEmpty ? context.l10n.helloUser(_name) : 'Bonjour',
                       style: const TextStyle(
                         fontSize: 28,
                         fontWeight: FontWeight.bold,

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -567,7 +567,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
               ),
               icon: const Icon(Icons.add_rounded, size: 18),
               label: Text(
-                context.l10n.addMedicationShort,
+                context.l10n.addMedication,
                 style:
                     const TextStyle(fontWeight: FontWeight.w700, fontSize: 13),
               ),

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -419,36 +419,44 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      context.l10n.todayIntakes,
-                      style: TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.w700,
-                        color: Color(0xFF1D1D1F),
-                        letterSpacing: -0.5,
-                      ),
-                    ),
-                    if (total > 0)
-                      Padding(
-                        padding: const EdgeInsets.only(top: 4),
-                        child: Text(
-                          context.l10n.todayIntakeProgress(takenCount, total),
-                          style: TextStyle(
-                            fontSize: 13,
-                            fontWeight: FontWeight.w600,
-                            color: takenCount == total
-                                ? const Color(0xFF34C759)
-                                : Colors.grey.shade500,
-                          ),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        context.l10n.todayIntakes,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.w700,
+                          color: Color(0xFF1D1D1F),
+                          letterSpacing: -0.5,
                         ),
                       ),
-                  ],
+                      if (total > 0)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: Text(
+                            context.l10n.todayIntakeProgress(takenCount, total),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontSize: 13,
+                              fontWeight: FontWeight.w600,
+                              color: takenCount == total
+                                  ? const Color(0xFF34C759)
+                                  : Colors.grey.shade500,
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
                 ),
-                Row(
-                  mainAxisSize: MainAxisSize.min,
+                const SizedBox(width: 8),
+                Wrap(
+                  spacing: 0,
+                  runSpacing: 0,
                   children: [
                     TextButton.icon(
                       onPressed: () => context.push('/pillbox/history'),
@@ -462,6 +470,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                       icon: const Icon(Icons.history_rounded, size: 16),
                       label: Text(context.l10n.history),
                     ),
+                    const SizedBox(width: 4),
                     TextButton.icon(
                       onPressed: () => context.push('/pillbox'),
                       style: TextButton.styleFrom(

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -141,7 +141,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      _name.isNotEmpty ? context.l10n.helloUser(_name) : 'Bonjour',
+                      _name.isNotEmpty
+                          ? context.l10n.helloUser(_name)
+                          : context.l10n.hello,
                       style: const TextStyle(
                         fontSize: 28,
                         fontWeight: FontWeight.bold,
@@ -156,13 +158,13 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                         color: const Color(0xFFF5F2C1),
                         borderRadius: BorderRadius.circular(12),
                       ),
-                      child: const Row(
+                      child: Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           Icon(Icons.star, size: 16, color: Color(0xFFFFBE0A)),
                           SizedBox(width: 4),
                           Text(
-                            'Membre Pro',
+                            context.l10n.proMember,
                             style: TextStyle(
                               fontSize: 13,
                               fontWeight: FontWeight.w700,
@@ -191,7 +193,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                   Icon(Icons.search, color: Colors.grey[600], size: 20),
                   const SizedBox(width: 12),
                   Text(
-                    'Commencer un chat avec DocAI',
+                    context.l10n.startChatDocAi,
                     style: TextStyle(fontSize: 16, color: Colors.grey[600]),
                   ),
                 ],
@@ -420,8 +422,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                 Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    const Text(
-                      'Prises du jour',
+                    Text(
+                      context.l10n.todayIntakes,
                       style: TextStyle(
                         fontSize: 18,
                         fontWeight: FontWeight.w700,
@@ -433,7 +435,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                       Padding(
                         padding: const EdgeInsets.only(top: 4),
                         child: Text(
-                          '$takenCount/$total prises effectuees',
+                          context.l10n.todayIntakeProgress(takenCount, total),
                           style: TextStyle(
                             fontSize: 13,
                             fontWeight: FontWeight.w600,
@@ -458,7 +460,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                         padding: const EdgeInsets.symmetric(horizontal: 8),
                       ),
                       icon: const Icon(Icons.history_rounded, size: 16),
-                      label: const Text('Historique'),
+                      label: Text(context.l10n.history),
                     ),
                     TextButton.icon(
                       onPressed: () => context.push('/pillbox'),
@@ -470,7 +472,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                         padding: const EdgeInsets.symmetric(horizontal: 8),
                       ),
                       icon: const Icon(Icons.arrow_forward, size: 16),
-                      label: const Text('Voir tout'),
+                      label: Text(context.l10n.viewAll),
                     ),
                   ],
                 ),
@@ -534,8 +536,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
           const Icon(Icons.check_circle_outline_rounded,
               size: 40, color: Color(0xFF34C759)),
           const SizedBox(height: 10),
-          const Text(
-            'Aucune prise prevue aujourd\'hui',
+          Text(
+            context.l10n.noIntakesToday,
             style: TextStyle(
               fontSize: 15,
               fontWeight: FontWeight.w700,
@@ -544,7 +546,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
           ),
           const SizedBox(height: 4),
           Text(
-            'Ajoutez des medicaments avec des horaires',
+            context.l10n.addMedicationsWithSchedules,
             style: TextStyle(
               fontSize: 13,
               color: Colors.grey.shade500,
@@ -564,9 +566,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                 ),
               ),
               icon: const Icon(Icons.add_rounded, size: 18),
-              label: const Text(
-                'Ajouter un medicament',
-                style: TextStyle(fontWeight: FontWeight.w700, fontSize: 13),
+              label: Text(
+                context.l10n.addMedicationShort,
+                style:
+                    const TextStyle(fontWeight: FontWeight.w700, fontSize: 13),
               ),
             ),
           ),

--- a/lib/features/home/presentation/widgets/recent_activity.dart
+++ b/lib/features/home/presentation/widgets/recent_activity.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 
 class ActivityItem {
   final String id;
@@ -44,7 +45,7 @@ class RecentActivity extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text(
-                'Recent Activity',
+                context.l10n.recentActivity,
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
                       fontWeight: FontWeight.bold,
                     ),
@@ -52,7 +53,7 @@ class RecentActivity extends StatelessWidget {
               if (onViewAll != null)
                 TextButton(
                   onPressed: onViewAll,
-                  child: const Text('View All'),
+                  child: Text(context.l10n.viewAll),
                 ),
             ],
           ),
@@ -123,7 +124,7 @@ class _ActivityItemCard extends StatelessWidget {
           ),
           const SizedBox(width: 8),
           Text(
-            DateFormat('MMM d').format(activity.date),
+            DateFormat('MMM d', 'fr_FR').format(activity.date),
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
                   color: Colors.grey[500],
                 ),

--- a/lib/features/home/presentation/widgets/recent_activity.dart
+++ b/lib/features/home/presentation/widgets/recent_activity.dart
@@ -32,6 +32,10 @@ class RecentActivity extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final localeName = Localizations.localeOf(context).languageCode == 'fr'
+        ? 'fr_FR'
+        : 'en_US';
+
     if (activities.isEmpty) {
       return const SizedBox.shrink();
     }
@@ -67,7 +71,10 @@ class RecentActivity extends StatelessWidget {
           separatorBuilder: (_, __) => const SizedBox(height: 12),
           itemBuilder: (context, index) {
             final activity = activities[index];
-            return _ActivityItemCard(activity: activity);
+            return _ActivityItemCard(
+              activity: activity,
+              localeName: localeName,
+            );
           },
         ),
       ],
@@ -77,9 +84,11 @@ class RecentActivity extends StatelessWidget {
 
 class _ActivityItemCard extends StatelessWidget {
   final ActivityItem activity;
+  final String localeName;
 
   const _ActivityItemCard({
     required this.activity,
+    required this.localeName,
   });
 
   @override
@@ -124,7 +133,7 @@ class _ActivityItemCard extends StatelessWidget {
           ),
           const SizedBox(width: 8),
           Text(
-            DateFormat('MMM d', 'fr_FR').format(activity.date),
+            DateFormat('d MMM', localeName).format(activity.date),
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
                   color: Colors.grey[500],
                 ),

--- a/lib/features/pillbox/presentation/screens/add_medication_screen.dart
+++ b/lib/features/pillbox/presentation/screens/add_medication_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import '../../../../../l10n/app_localizations.dart';
 import '../../domain/entities/medication_search_result.dart';
 import '../providers/medication_search_provider.dart';
 import '../providers/pillbox_provider.dart';
@@ -421,7 +422,7 @@ class _AddMedicationScreenState extends State<AddMedicationScreen> {
           const SizedBox(height: 14),
           _styledTextField(
             controller: _instructionsController,
-            label: 'Instructions',
+            label: context.l10n.instructions,
             icon: Icons.note_outlined,
             maxLines: 2,
           ),

--- a/lib/features/pillbox/presentation/screens/add_medication_screen.dart
+++ b/lib/features/pillbox/presentation/screens/add_medication_screen.dart
@@ -463,7 +463,7 @@ class _AddMedicationScreenState extends State<AddMedicationScreen> {
           _datePickerTile(
             label: context.l10n.end,
             date: _endDate,
-            placeholder: 'Aucune',
+            placeholder: context.l10n.none,
             onPick: _pickEndDate,
             onClear: _endDate != null ? () => setState(() => _endDate = null) : null,
           ),
@@ -481,10 +481,10 @@ class _AddMedicationScreenState extends State<AddMedicationScreen> {
             spacing: 8,
             runSpacing: 8,
             children: [
-              _momentChip('MORNING', 'Matin', Icons.wb_sunny_rounded),
-              _momentChip('NOON', 'Midi', Icons.wb_twilight_rounded),
-              _momentChip('EVENING', 'Soir', Icons.nights_stay_rounded),
-              _momentChip('BEDTIME', 'Coucher', Icons.bedtime_rounded),
+              _momentChip('MORNING', context.l10n.morning, Icons.wb_sunny_rounded),
+              _momentChip('NOON', context.l10n.noon, Icons.wb_twilight_rounded),
+              _momentChip('EVENING', context.l10n.evening, Icons.nights_stay_rounded),
+              _momentChip('BEDTIME', context.l10n.bedtime, Icons.bedtime_rounded),
               _momentChip('CUSTOM', context.l10n.other, Icons.more_horiz_rounded),
             ],
           ),

--- a/lib/features/pillbox/presentation/screens/add_medication_screen.dart
+++ b/lib/features/pillbox/presentation/screens/add_medication_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import '../../../../../l10n/app_localizations.dart';
 import '../../domain/entities/medication_search_result.dart';
@@ -102,8 +103,8 @@ class _AddMedicationScreenState extends State<AddMedicationScreen> {
                       color: Colors.white,
                     ),
                   )
-                : const Text(
-                    'Ajouter au pilulier',
+                : Text(
+                    context.l10n.addToPillbox,
                     style: TextStyle(
                       fontWeight: FontWeight.w800,
                       fontSize: 16,
@@ -134,8 +135,8 @@ class _AddMedicationScreenState extends State<AddMedicationScreen> {
           }
         },
       ),
-      title: const Text(
-        'Ajouter un medicament',
+      title: Text(
+        context.l10n.addMedication,
         style: TextStyle(
           fontSize: 20,
           fontWeight: FontWeight.w800,
@@ -214,15 +215,15 @@ class _AddMedicationScreenState extends State<AddMedicationScreen> {
 
   Widget _buildSearchCard(MedicationSearchProvider searchProvider) {
     return _card(
-      title: 'Recherche',
+      title: context.l10n.search,
       child: Column(
         children: [
           _styledTextField(
             controller: _searchController,
-            label: 'Rechercher un medicament',
+            label: context.l10n.searchMedication,
             icon: Icons.search_rounded,
             onChanged: context.read<MedicationSearchProvider>().search,
-            hint: 'Minimum 3 caracteres',
+            hint: context.l10n.minimum3Characters,
           ),
           if (searchProvider.isSearching) ...[
             const SizedBox(height: 12),
@@ -298,10 +299,10 @@ class _AddMedicationScreenState extends State<AddMedicationScreen> {
                   Icon(Icons.info_outline_rounded,
                       size: 18, color: Colors.grey.shade400),
                   const SizedBox(width: 10),
-                  const Expanded(
+                  Expanded(
                     child: Text(
-                      'Aucun resultat. Essaie un nom de molecule (ex: paracetamol).',
-                      style: TextStyle(color: _grey, fontSize: 13),
+                      context.l10n.noResultsFound,
+                      style: const TextStyle(color: _grey, fontSize: 13),
                     ),
                   ),
                 ],
@@ -402,21 +403,21 @@ class _AddMedicationScreenState extends State<AddMedicationScreen> {
 
   Widget _buildInfoCard() {
     return _card(
-      title: 'Informations',
+      title: context.l10n.information,
       child: Column(
         children: [
           _styledTextFormField(
             controller: _nameController,
-            label: 'Nom du medicament',
+            label: context.l10n.medicationName,
             icon: Icons.medication_rounded,
             validator: (value) => (value == null || value.trim().isEmpty)
-                ? 'Champ requis'
+                ? context.l10n.requiredField
                 : null,
           ),
           const SizedBox(height: 14),
           _styledTextField(
             controller: _dosageController,
-            label: 'Posologie',
+            label: context.l10n.dosage,
             icon: Icons.description_outlined,
           ),
           const SizedBox(height: 14),
@@ -435,7 +436,7 @@ class _AddMedicationScreenState extends State<AddMedicationScreen> {
 
   Widget _buildScheduleCard() {
     return _card(
-      title: 'Plan de prise',
+      title: context.l10n.scheduleTimes,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -443,7 +444,7 @@ class _AddMedicationScreenState extends State<AddMedicationScreen> {
             children: [
               Expanded(
                 child: _datePickerTile(
-                  label: 'Date de debut',
+                  label: context.l10n.start,
                   date: _startDate,
                   onPick: _pickStartDate,
                 ),
@@ -451,7 +452,7 @@ class _AddMedicationScreenState extends State<AddMedicationScreen> {
               const SizedBox(width: 12),
               Expanded(
                 child: _timePickerTile(
-                  label: 'Horaire',
+                  label: context.l10n.timeOfIntake,
                   time: _time,
                   onPick: _pickTime,
                 ),
@@ -460,15 +461,15 @@ class _AddMedicationScreenState extends State<AddMedicationScreen> {
           ),
           const SizedBox(height: 12),
           _datePickerTile(
-            label: 'Date de fin',
+            label: context.l10n.end,
             date: _endDate,
             placeholder: 'Aucune',
             onPick: _pickEndDate,
             onClear: _endDate != null ? () => setState(() => _endDate = null) : null,
           ),
           const SizedBox(height: 14),
-          const Text(
-            'Moment de la journee',
+          Text(
+            context.l10n.momentOfDay,
             style: TextStyle(
               fontSize: 13,
               fontWeight: FontWeight.w700,
@@ -484,7 +485,7 @@ class _AddMedicationScreenState extends State<AddMedicationScreen> {
               _momentChip('NOON', 'Midi', Icons.wb_twilight_rounded),
               _momentChip('EVENING', 'Soir', Icons.nights_stay_rounded),
               _momentChip('BEDTIME', 'Coucher', Icons.bedtime_rounded),
-              _momentChip('CUSTOM', 'Autre', Icons.more_horiz_rounded),
+              _momentChip('CUSTOM', context.l10n.other, Icons.more_horiz_rounded),
             ],
           ),
           const SizedBox(height: 14),
@@ -493,7 +494,7 @@ class _AddMedicationScreenState extends State<AddMedicationScreen> {
               Expanded(
                 child: _styledTextField(
                   controller: _quantityController,
-                  label: 'Quantite',
+                  label: context.l10n.quantity,
                   icon: Icons.numbers_rounded,
                   keyboardType: TextInputType.number,
                 ),
@@ -502,7 +503,7 @@ class _AddMedicationScreenState extends State<AddMedicationScreen> {
               Expanded(
                 child: _styledTextField(
                   controller: _unitController,
-                  label: 'Unite (mg, ml...)',
+                  label: context.l10n.unitExamples,
                   icon: Icons.straighten_rounded,
                 ),
               ),
@@ -901,10 +902,6 @@ class _AddMedicationScreenState extends State<AddMedicationScreen> {
   }
 
   String _formatDateFr(DateTime date) {
-    const months = [
-      '', 'janvier', 'fevrier', 'mars', 'avril', 'mai', 'juin',
-      'juillet', 'aout', 'septembre', 'octobre', 'novembre', 'decembre',
-    ];
-    return '${date.day} ${months[date.month]} ${date.year}';
+    return DateFormat.yMMMMd('fr_FR').format(date);
   }
 }

--- a/lib/features/pillbox/presentation/screens/intake_history_screen.dart
+++ b/lib/features/pillbox/presentation/screens/intake_history_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 import '../providers/pillbox_provider.dart';
 import '../widgets/intake_card.dart';
 
@@ -73,8 +74,8 @@ class _IntakeHistoryScreenState extends State<IntakeHistoryScreen> {
               icon: const Icon(Icons.arrow_back_ios_new_rounded, size: 20, color: _dark),
               onPressed: () => context.pop(),
             ),
-            title: const Text(
-              'Historique',
+            title: Text(
+              context.l10n.history,
               style: TextStyle(
                 fontSize: 18,
                 fontWeight: FontWeight.w700,
@@ -394,7 +395,7 @@ class _IntakeHistoryScreenState extends State<IntakeHistoryScreen> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Text(
-                  _formatSelectedDate(),
+                  _formatSelectedDate(context),
                   style: const TextStyle(
                     fontSize: 17,
                     fontWeight: FontWeight.w700,
@@ -498,8 +499,8 @@ class _IntakeHistoryScreenState extends State<IntakeHistoryScreen> {
           const Icon(Icons.event_available_rounded,
               size: 40, color: _green),
           const SizedBox(height: 10),
-          const Text(
-            'Aucune prise ce jour',
+          Text(
+            context.l10n.noIntakesToday,
             style: TextStyle(
               fontSize: 15,
               fontWeight: FontWeight.w700,
@@ -508,7 +509,7 @@ class _IntakeHistoryScreenState extends State<IntakeHistoryScreen> {
           ),
           const SizedBox(height: 4),
           Text(
-            'Pas de medicaments programmes',
+            context.l10n.noMedicationsScheduled,
             style: TextStyle(
               fontSize: 13,
               color: Colors.grey.shade500,
@@ -521,14 +522,14 @@ class _IntakeHistoryScreenState extends State<IntakeHistoryScreen> {
 
   // ── Helpers ─────────────────────────────────────────────────────────────
 
-  String _formatSelectedDate() {
+  String _formatSelectedDate(BuildContext context) {
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day);
     final sel = DateTime(_selectedDate.year, _selectedDate.month, _selectedDate.day);
     final yesterday = today.subtract(const Duration(days: 1));
 
-    if (sel == today) return "Aujourd'hui";
-    if (sel == yesterday) return 'Hier';
+    if (sel == today) return context.l10n.today;
+    if (sel == yesterday) return context.l10n.yesterday;
 
     final dayNames = [
       '', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi', 'Dimanche'

--- a/lib/features/pillbox/presentation/screens/medication_detail_screen.dart
+++ b/lib/features/pillbox/presentation/screens/medication_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import '../../../../../l10n/app_localizations.dart';
 import '../../domain/entities/medication_schedule.dart';
 import '../../domain/entities/patient_medication.dart';
 import '../providers/pillbox_provider.dart';
@@ -274,7 +275,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
           _divider(),
           _infoRow(
             Icons.description_outlined,
-            'Instructions',
+            context.l10n.instructions,
             medication.instructions ?? 'Aucune instruction',
           ),
           _divider(),
@@ -753,7 +754,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                   const SizedBox(height: 14),
                   _sheetTextField(
                     controller: instructionsController,
-                    label: 'Instructions',
+                    label: context.l10n.instructions,
                     icon: Icons.description_outlined,
                     maxLines: 3,
                   ),

--- a/lib/features/pillbox/presentation/screens/medication_detail_screen.dart
+++ b/lib/features/pillbox/presentation/screens/medication_detail_screen.dart
@@ -46,7 +46,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
     setState(() {
       _medication = data;
       _loading = false;
-      if (data == null) _error = 'Medicament introuvable';
+      if (data == null) _error = context.l10n.medicationNotFound;
     });
   }
 
@@ -100,9 +100,9 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                 TextButton.icon(
                   onPressed: _load,
                   icon: const Icon(Icons.refresh_rounded, color: _green),
-                  label: const Text(
-                    'Reessayer',
-                    style: TextStyle(
+                  label: Text(
+                    context.l10n.retry,
+                    style: const TextStyle(
                       color: _green,
                       fontWeight: FontWeight.w700,
                     ),
@@ -158,9 +158,9 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
           }
         },
       ),
-      title: const Text(
-        'Detail medicament',
-        style: TextStyle(
+      title: Text(
+        context.l10n.medicationDetails,
+        style: const TextStyle(
           fontSize: 20,
           fontWeight: FontWeight.w800,
           color: _dark,
@@ -258,9 +258,9 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
-            'Informations',
-            style: TextStyle(
+          Text(
+            context.l10n.information,
+            style: const TextStyle(
               fontSize: 17,
               fontWeight: FontWeight.w800,
               color: _dark,
@@ -269,26 +269,26 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
           const SizedBox(height: 14),
           _infoRow(
             Icons.medication_rounded,
-            'Posologie',
-            medication.dosageLabel ?? 'Non renseignee',
+            context.l10n.dosage,
+            medication.dosageLabel ?? context.l10n.notProvided,
           ),
           _divider(),
           _infoRow(
             Icons.description_outlined,
             context.l10n.instructions,
-            medication.instructions ?? 'Aucune instruction',
+            medication.instructions ?? context.l10n.noInstruction,
           ),
           _divider(),
           _infoRow(
             Icons.calendar_today_rounded,
-            'Date de debut',
+            context.l10n.start,
             _formatDateFr(medication.startDate),
           ),
           if (medication.endDate != null) ...[
             _divider(),
             _infoRow(
               Icons.event_rounded,
-              'Date de fin',
+              context.l10n.end,
               _formatDateFr(medication.endDate!),
             ),
           ],
@@ -296,7 +296,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
             _divider(),
             _infoRow(
               Icons.science_outlined,
-              'Substances actives',
+              context.l10n.activeSubstances,
               medication.activeSubstances.join(', '),
             ),
           ],
@@ -306,9 +306,9 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
             child: TextButton.icon(
               onPressed: _editMedication,
               icon: const Icon(Icons.edit_rounded, size: 16, color: _green),
-              label: const Text(
-                'Modifier',
-                style: TextStyle(
+              label: Text(
+                context.l10n.edit,
+                style: const TextStyle(
                   color: _green,
                   fontWeight: FontWeight.w700,
                   fontSize: 14,
@@ -397,7 +397,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               const Text(
-                'Horaires de prise',
+              context.l10n.scheduleTimes,
                 style: TextStyle(
                   fontSize: 17,
                   fontWeight: FontWeight.w800,
@@ -419,8 +419,8 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                       Icon(Icons.add_rounded, size: 16, color: _green),
                       SizedBox(width: 4),
                       Text(
-                        'Ajouter',
-                        style: TextStyle(
+                        context.l10n.add,
+                        style: const TextStyle(
                           color: _green,
                           fontWeight: FontWeight.w700,
                           fontSize: 13,
@@ -447,7 +447,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                       size: 32, color: Colors.grey.shade400),
                   const SizedBox(height: 8),
                   Text(
-                    'Aucun horaire configure',
+                    context.l10n.noScheduleConfigured,
                     style: TextStyle(
                       color: Colors.grey.shade500,
                       fontWeight: FontWeight.w600,
@@ -456,7 +456,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                   ),
                   const SizedBox(height: 4),
                   Text(
-                    'Ajoutez un horaire pour suivre vos prises',
+                    context.l10n.addScheduleToTrack,
                     style: TextStyle(
                       color: Colors.grey.shade400,
                       fontSize: 12,
@@ -586,7 +586,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const Text(
-            'Actions',
+            context.l10n.actions,
             style: TextStyle(
               fontSize: 17,
               fontWeight: FontWeight.w800,
@@ -599,8 +599,8 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                 ? Icons.pause_circle_outline_rounded
                 : Icons.play_circle_outline_rounded,
             label: medication.isActive
-                ? 'Desactiver le medicament'
-                : 'Reactiver le medicament',
+                ? context.l10n.disableMedication
+                : context.l10n.enableMedication,
             color: medication.isActive
                 ? const Color(0xFFFF9500)
                 : _green,
@@ -612,7 +612,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
           const SizedBox(height: 10),
           _actionButton(
             icon: Icons.delete_outline_rounded,
-            label: 'Supprimer le medicament',
+            label: context.l10n.deleteMedication,
             color: const Color(0xFFEF4444),
             bgColor: const Color(0xFFFEE2E2),
             onTap: _deleteMedication,
@@ -737,9 +737,9 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                     ),
                   ),
                   const SizedBox(height: 16),
-                  const Text(
-                    'Modifier le medicament',
-                    style: TextStyle(
+                  Text(
+                    context.l10n.editMedication,
+                    style: const TextStyle(
                       fontSize: 20,
                       fontWeight: FontWeight.w800,
                       color: _dark,
@@ -748,7 +748,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                   const SizedBox(height: 20),
                   _sheetTextField(
                     controller: dosageController,
-                    label: 'Posologie',
+                    label: context.l10n.dosage,
                     icon: Icons.medication_rounded,
                   ),
                   const SizedBox(height: 14),
@@ -760,7 +760,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                   ),
                   const SizedBox(height: 14),
                   _datePickerTile(
-                    label: 'Date de debut',
+                    label: context.l10n.start,
                     date: startDate,
                     onPick: () async {
                       final picked = await showDatePicker(
@@ -776,7 +776,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                   ),
                   const SizedBox(height: 10),
                   _datePickerTile(
-                    label: 'Date de fin',
+                    label: context.l10n.end,
                     date: endDate,
                     placeholder: 'Aucune',
                     onPick: () async {
@@ -808,9 +808,9 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                                 borderRadius: BorderRadius.circular(14),
                               ),
                             ),
-                            child: const Text(
-                              'Annuler',
-                              style: TextStyle(
+                            child: Text(
+                              context.l10n.cancel,
+                              style: const TextStyle(
                                 color: _grey,
                                 fontWeight: FontWeight.w700,
                               ),
@@ -832,9 +832,9 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                                 borderRadius: BorderRadius.circular(14),
                               ),
                             ),
-                            child: const Text(
-                              'Enregistrer',
-                              style: TextStyle(fontWeight: FontWeight.w700),
+                            child: Text(
+                              context.l10n.save,
+                              style: const TextStyle(fontWeight: FontWeight.w700),
                             ),
                           ),
                         ),
@@ -927,8 +927,8 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                   const SizedBox(height: 16),
                   Text(
                     schedule == null
-                        ? 'Ajouter un horaire'
-                        : 'Modifier l\'horaire',
+                        ? context.l10n.addSchedule
+                        : context.l10n.modifySchedule,
                     style: const TextStyle(
                       fontSize: 20,
                       fontWeight: FontWeight.w800,
@@ -965,7 +965,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               const Text(
-                                'Heure de prise',
+                                context.l10n.timeOfIntake,
                                 style: TextStyle(
                                   fontSize: 12,
                                   color: _grey,
@@ -993,7 +993,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                   const SizedBox(height: 14),
                   // Intake moment chips
                   const Text(
-                    'Moment de la journee',
+                    context.l10n.momentOfDay,
                     style: TextStyle(
                       fontSize: 13,
                       fontWeight: FontWeight.w700,
@@ -1033,7 +1033,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                       Expanded(
                         child: _sheetTextField(
                           controller: quantityController,
-                          label: 'Quantite',
+                          label: context.l10n.quantity,
                           icon: Icons.numbers_rounded,
                           keyboardType: TextInputType.number,
                         ),
@@ -1042,7 +1042,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                       Expanded(
                         child: _sheetTextField(
                           controller: unitController,
-                          label: 'Unite (mg, ml...)',
+                          label: context.l10n.unitExamples,
                           icon: Icons.straighten_rounded,
                         ),
                       ),
@@ -1051,7 +1051,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                   const SizedBox(height: 14),
                   _sheetTextField(
                     controller: notesController,
-                    label: 'Notes (optionnel)',
+                    label: context.l10n.notesOptional,
                     icon: Icons.note_outlined,
                     maxLines: 2,
                   ),
@@ -1069,9 +1069,9 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                                 borderRadius: BorderRadius.circular(14),
                               ),
                             ),
-                            child: const Text(
-                              'Annuler',
-                              style: TextStyle(
+                            child: Text(
+                              context.l10n.cancel,
+                              style: const TextStyle(
                                 color: _grey,
                                 fontWeight: FontWeight.w700,
                               ),
@@ -1093,9 +1093,9 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                                 borderRadius: BorderRadius.circular(14),
                               ),
                             ),
-                            child: const Text(
-                              'Enregistrer',
-                              style: TextStyle(fontWeight: FontWeight.w700),
+                            child: Text(
+                              context.l10n.save,
+                              style: const TextStyle(fontWeight: FontWeight.w700),
                             ),
                           ),
                         ),
@@ -1148,20 +1148,20 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(18),
             ),
-            title: const Text(
-              'Supprimer cet horaire ?',
-              style: TextStyle(fontWeight: FontWeight.w800, fontSize: 18),
+            title: Text(
+              context.l10n.deleteScheduleConfirm,
+              style: const TextStyle(fontWeight: FontWeight.w800, fontSize: 18),
             ),
-            content: const Text(
-              'Cette action est irreversible.',
-              style: TextStyle(color: _grey),
+            content: Text(
+              context.l10n.irreversibleAction,
+              style: const TextStyle(color: _grey),
             ),
             actions: [
               TextButton(
                 onPressed: () => Navigator.pop(context, false),
-                child: const Text(
-                  'Annuler',
-                  style: TextStyle(color: _grey, fontWeight: FontWeight.w700),
+                child: Text(
+                  context.l10n.cancel,
+                  style: const TextStyle(color: _grey, fontWeight: FontWeight.w700),
                 ),
               ),
               ElevatedButton(
@@ -1174,9 +1174,9 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                     borderRadius: BorderRadius.circular(12),
                   ),
                 ),
-                child: const Text(
-                  'Supprimer',
-                  style: TextStyle(fontWeight: FontWeight.w700),
+                child: Text(
+                  context.l10n.delete,
+                  style: const TextStyle(fontWeight: FontWeight.w700),
                 ),
               ),
             ],
@@ -1220,20 +1220,20 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(18),
             ),
-            title: const Text(
-              'Supprimer ce medicament ?',
-              style: TextStyle(fontWeight: FontWeight.w800, fontSize: 18),
+            title: Text(
+              context.l10n.confirmDeleteMedication,
+              style: const TextStyle(fontWeight: FontWeight.w800, fontSize: 18),
             ),
-            content: const Text(
-              'Le medicament et tous ses horaires seront supprimes definitivement.',
-              style: TextStyle(color: _grey),
+            content: Text(
+              context.l10n.medicationDeleteWarning,
+              style: const TextStyle(color: _grey),
             ),
             actions: [
               TextButton(
                 onPressed: () => Navigator.pop(context, false),
-                child: const Text(
-                  'Annuler',
-                  style: TextStyle(color: _grey, fontWeight: FontWeight.w700),
+                child: Text(
+                  context.l10n.cancel,
+                  style: const TextStyle(color: _grey, fontWeight: FontWeight.w700),
                 ),
               ),
               ElevatedButton(
@@ -1246,9 +1246,9 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                     borderRadius: BorderRadius.circular(12),
                   ),
                 ),
-                child: const Text(
-                  'Supprimer',
-                  style: TextStyle(fontWeight: FontWeight.w700),
+                child: Text(
+                  context.l10n.delete,
+                  style: const TextStyle(fontWeight: FontWeight.w700),
                 ),
               ),
             ],
@@ -1475,7 +1475,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
     if (schedule.notes != null && schedule.notes!.isNotEmpty) {
       parts.add(schedule.notes!);
     }
-    return parts.isEmpty ? 'Aucun detail' : parts.join(' - ');
+    return parts.isEmpty ? context.l10n.noDetails : parts.join(' - ');
   }
 
   String _formEmoji(PatientMedication medication) {

--- a/lib/features/pillbox/presentation/screens/medication_detail_screen.dart
+++ b/lib/features/pillbox/presentation/screens/medication_detail_screen.dart
@@ -396,8 +396,8 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              const Text(
-              context.l10n.scheduleTimes,
+              Text(
+                context.l10n.scheduleTimes,
                 style: TextStyle(
                   fontSize: 17,
                   fontWeight: FontWeight.w800,
@@ -413,7 +413,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                     color: const Color(0xFFEAF9F0),
                     borderRadius: BorderRadius.circular(12),
                   ),
-                  child: const Row(
+                  child: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       Icon(Icons.add_rounded, size: 16, color: _green),
@@ -585,7 +585,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
+          Text(
             context.l10n.actions,
             style: TextStyle(
               fontSize: 17,
@@ -964,7 +964,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                           Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              const Text(
+                              Text(
                                 context.l10n.timeOfIntake,
                                 style: TextStyle(
                                   fontSize: 12,
@@ -992,7 +992,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                   ),
                   const SizedBox(height: 14),
                   // Intake moment chips
-                  const Text(
+                  Text(
                     context.l10n.momentOfDay,
                     style: TextStyle(
                       fontSize: 13,

--- a/lib/features/pillbox/presentation/screens/medication_detail_screen.dart
+++ b/lib/features/pillbox/presentation/screens/medication_detail_screen.dart
@@ -515,7 +515,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  _momentLabel(schedule.intakeMoment),
+                  _momentLabel(context, schedule.intakeMoment),
                   style: const TextStyle(
                     fontSize: 15,
                     fontWeight: FontWeight.w700,
@@ -681,7 +681,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
           ),
           const SizedBox(width: 6),
           Text(
-            isActive ? 'Actif' : 'Inactif',
+            isActive ? context.l10n.active : context.l10n.inactive,
             style: TextStyle(
               fontWeight: FontWeight.w700,
               fontSize: 13,
@@ -760,6 +760,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                   ),
                   const SizedBox(height: 14),
                   _datePickerTile(
+                    context: context,
                     label: context.l10n.start,
                     date: startDate,
                     onPick: () async {
@@ -776,9 +777,10 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                   ),
                   const SizedBox(height: 10),
                   _datePickerTile(
+                    context: context,
                     label: context.l10n.end,
                     date: endDate,
-                    placeholder: 'Aucune',
+                    placeholder: context.l10n.none,
                     onPick: () async {
                       final picked = await showDatePicker(
                         context: context,
@@ -1005,23 +1007,23 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                     spacing: 8,
                     runSpacing: 8,
                     children: [
-                      _momentChip('MORNING', 'Matin', Icons.wb_sunny_rounded,
+                      _momentChip('MORNING', context.l10n.morning, Icons.wb_sunny_rounded,
                           intakeMoment, (v) {
                         setModalState(() => intakeMoment = v);
                       }),
-                      _momentChip('NOON', 'Midi',
+                      _momentChip('NOON', context.l10n.noon,
                           Icons.wb_twilight_rounded, intakeMoment, (v) {
                         setModalState(() => intakeMoment = v);
                       }),
-                      _momentChip('EVENING', 'Soir',
+                      _momentChip('EVENING', context.l10n.evening,
                           Icons.nights_stay_rounded, intakeMoment, (v) {
                         setModalState(() => intakeMoment = v);
                       }),
-                      _momentChip('BEDTIME', 'Coucher',
+                      _momentChip('BEDTIME', context.l10n.bedtime,
                           Icons.bedtime_rounded, intakeMoment, (v) {
                         setModalState(() => intakeMoment = v);
                       }),
-                      _momentChip('CUSTOM', 'Autre',
+                      _momentChip('CUSTOM', context.l10n.custom,
                           Icons.more_horiz_rounded, intakeMoment, (v) {
                         setModalState(() => intakeMoment = v);
                       }),
@@ -1308,6 +1310,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
   }
 
   Widget _datePickerTile({
+    required BuildContext context,
     required String label,
     DateTime? date,
     String? placeholder,
@@ -1344,7 +1347,7 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
                   Text(
                     date != null
                         ? _formatDateFr(date)
-                        : (placeholder ?? 'Aucune'),
+                        : (placeholder ?? context.l10n.none),
                     style: TextStyle(
                       fontSize: 15,
                       fontWeight: FontWeight.w600,
@@ -1434,18 +1437,18 @@ class _MedicationDetailScreenState extends State<MedicationDetailScreen> {
     );
   }
 
-  String _momentLabel(String moment) {
+  String _momentLabel(BuildContext context, String moment) {
     switch (moment.toUpperCase()) {
       case 'MORNING':
-        return 'Matin';
+        return context.l10n.morning;
       case 'NOON':
-        return 'Midi';
+        return context.l10n.noon;
       case 'EVENING':
-        return 'Soir';
+        return context.l10n.evening;
       case 'BEDTIME':
-        return 'Coucher';
+        return context.l10n.bedtime;
       default:
-        return 'Personnalise';
+        return context.l10n.custom;
     }
   }
 

--- a/lib/features/pillbox/presentation/screens/pillbox_screen.dart
+++ b/lib/features/pillbox/presentation/screens/pillbox_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 import '../../domain/entities/patient_medication.dart';
 import '../providers/pillbox_provider.dart';
 import '../widgets/medication_list_card.dart';
@@ -65,8 +66,8 @@ class _PillboxScreenState extends State<PillboxScreen> {
                     }
                   },
                 ),
-                title: const Text(
-                  'Plan de medicaments',
+                title: Text(
+                  context.l10n.medicationPlan,
                   style: TextStyle(
                     fontSize: 20,
                     fontWeight: FontWeight.w800,
@@ -78,7 +79,7 @@ class _PillboxScreenState extends State<PillboxScreen> {
                   IconButton(
                     icon: const Icon(Icons.history_rounded,
                         size: 22, color: Color.fromARGB(255, 0, 0, 0)),
-                    tooltip: 'Historique',
+                    tooltip: context.l10n.history,
                     onPressed: () => context.push('/pillbox/history'),
                   ),
                 ],
@@ -102,7 +103,7 @@ class _PillboxScreenState extends State<PillboxScreen> {
                       Row(
                         children: [
                           _SummaryCard(
-                            label: 'Total',
+                            label: context.l10n.total,
                             count: provider.medications.length,
                             icon: Icons.medication_rounded,
                             color: const Color(0xFF34C759),
@@ -110,7 +111,7 @@ class _PillboxScreenState extends State<PillboxScreen> {
                           ),
                           const SizedBox(width: 10),
                           _SummaryCard(
-                            label: 'Actifs',
+                            label: context.l10n.active,
                             count: activeCount,
                             icon: Icons.check_circle_outline_rounded,
                             color: const Color(0xFF007AFF),
@@ -118,7 +119,7 @@ class _PillboxScreenState extends State<PillboxScreen> {
                           ),
                           const SizedBox(width: 10),
                           _SummaryCard(
-                            label: 'Inactifs',
+                            label: context.l10n.inactive,
                             count: inactiveCount,
                             icon: Icons.pause_circle_outline_rounded,
                             color: const Color(0xFFFF9500),
@@ -133,21 +134,21 @@ class _PillboxScreenState extends State<PillboxScreen> {
                       Row(
                         children: [
                           _FilterChip(
-                            label: 'Tous',
+                            label: context.l10n.all,
                             selected: _filter == _Filter.all,
                             onTap: () =>
                                 setState(() => _filter = _Filter.all),
                           ),
                           const SizedBox(width: 8),
                           _FilterChip(
-                            label: 'Actifs',
+                            label: context.l10n.active,
                             selected: _filter == _Filter.active,
                             onTap: () =>
                                 setState(() => _filter = _Filter.active),
                           ),
                           const SizedBox(width: 8),
                           _FilterChip(
-                            label: 'Inactifs',
+                            label: context.l10n.inactive,
                             selected: _filter == _Filter.inactive,
                             onTap: () =>
                                 setState(() => _filter = _Filter.inactive),
@@ -195,8 +196,8 @@ class _PillboxScreenState extends State<PillboxScreen> {
                         const SizedBox(height: 12),
                         Text(
                           _filter == _Filter.active
-                            ? 'Aucun medicament actif'
-                              : 'Aucun medicament inactif',
+                              ? context.l10n.noMedicationsActive
+                              : context.l10n.noMedicationsInactive,
                           style: TextStyle(
                             fontSize: 16,
                             fontWeight: FontWeight.w600,
@@ -246,8 +247,8 @@ class _PillboxScreenState extends State<PillboxScreen> {
                                       ),
                                 label: Text(
                                   provider.isLoading
-                                  ? 'Chargement...'
-                                  : 'Charger plus',
+                                      ? context.l10n.loading
+                                      : context.l10n.loadMore,
                                   style: const TextStyle(
                                     color: Color(0xFF34C759),
                                     fontWeight: FontWeight.w700,
@@ -273,8 +274,8 @@ class _PillboxScreenState extends State<PillboxScreen> {
         elevation: 4,
         onPressed: () => context.push('/pillbox/add'),
         icon: const Icon(Icons.add_rounded, color: Colors.white),
-        label: const Text(
-          'Ajouter',
+        label: Text(
+          context.l10n.addMedication,
           style: TextStyle(
             color: Colors.white,
             fontWeight: FontWeight.w700,
@@ -304,8 +305,8 @@ class _PillboxScreenState extends State<PillboxScreen> {
               ),
             ),
             const SizedBox(height: 20),
-            const Text(
-              'Votre pilulier est vide',
+            Text(
+              context.l10n.emptyPillboxTitle,
               style: TextStyle(
                 fontSize: 22,
                 fontWeight: FontWeight.w800,
@@ -315,7 +316,7 @@ class _PillboxScreenState extends State<PillboxScreen> {
             ),
             const SizedBox(height: 8),
             Text(
-              'Ajoutez votre premier medicament\npour commencer votre suivi.',
+              context.l10n.emptyPillboxSubtitle,
               textAlign: TextAlign.center,
               style: TextStyle(
                 color: Colors.grey.shade600,
@@ -338,8 +339,8 @@ class _PillboxScreenState extends State<PillboxScreen> {
                   ),
                 ),
                 icon: const Icon(Icons.add_rounded),
-                label: const Text(
-                  'Ajouter un medicament',
+                label: Text(
+                  context.l10n.addMedication,
                   style: TextStyle(
                     fontWeight: FontWeight.w700,
                     fontSize: 16,
@@ -388,8 +389,8 @@ class _PillboxScreenState extends State<PillboxScreen> {
               onPressed: () => provider.loadMedications(refresh: true),
               icon: const Icon(Icons.refresh_rounded,
                   color: Color(0xFF34C759)),
-              label: const Text(
-                'Reessayer',
+              label: Text(
+                context.l10n.retry,
                 style: TextStyle(
                   color: Color(0xFF34C759),
                   fontWeight: FontWeight.w700,

--- a/lib/features/pillbox/presentation/screens/pillbox_screen.dart
+++ b/lib/features/pillbox/presentation/screens/pillbox_screen.dart
@@ -66,7 +66,7 @@ class _PillboxScreenState extends State<PillboxScreen> {
                   },
                 ),
                 title: const Text(
-                  'Medication Plan',
+                  'Plan de medicaments',
                   style: TextStyle(
                     fontSize: 20,
                     fontWeight: FontWeight.w800,
@@ -195,7 +195,7 @@ class _PillboxScreenState extends State<PillboxScreen> {
                         const SizedBox(height: 12),
                         Text(
                           _filter == _Filter.active
-                              ? 'Aucun medicament actif'
+                            ? 'Aucun medicament actif'
                               : 'Aucun medicament inactif',
                           style: TextStyle(
                             fontSize: 16,
@@ -246,8 +246,8 @@ class _PillboxScreenState extends State<PillboxScreen> {
                                       ),
                                 label: Text(
                                   provider.isLoading
-                                      ? 'Chargement...'
-                                      : 'Charger plus',
+                                  ? 'Chargement...'
+                                  : 'Charger plus',
                                   style: const TextStyle(
                                     color: Color(0xFF34C759),
                                     fontWeight: FontWeight.w700,

--- a/lib/features/pillbox/presentation/widgets/medication_list_card.dart
+++ b/lib/features/pillbox/presentation/widgets/medication_list_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 import '../../domain/entities/patient_medication.dart';
 
 class MedicationListCard extends StatelessWidget {
@@ -140,7 +141,7 @@ class MedicationListCard extends StatelessWidget {
                     borderRadius: BorderRadius.circular(10),
                   ),
                   child: Text(
-                    medication.isActive ? 'Actif' : 'Inactif',
+                    medication.isActive ? context.l10n.active : context.l10n.inactive,
                     style: TextStyle(
                       color: medication.isActive
                           ? const Color(0xFF34C759)

--- a/lib/features/statistics/presentation/screens/statistics_screen.dart
+++ b/lib/features/statistics/presentation/screens/statistics_screen.dart
@@ -30,7 +30,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
     {'id': 'bloodPressure', 'icon': Icons.favorite, 'color': Color(0xFFFF3B30), 'unit': 'mmHg'},
     {'id': 'bloodGlucose', 'icon': Icons.water_drop, 'color': Color(0xFF5856D6), 'unit': 'mg/dL'},
     {'id': 'heartRate', 'icon': Icons.monitor_heart, 'color': Color(0xFFFF2D55), 'unit': 'bpm'},
-    {'name': 'Température', 'icon': Icons.thermostat, 'color': Color(0xFFFF9500), 'unit': '°C'},
+    {'id': 'temperature', 'icon': Icons.thermostat, 'color': Color(0xFFFF9500), 'unit': '°C'},
   ];
 
   List<Map<String, dynamic>> _getChartData() {

--- a/lib/features/statistics/presentation/screens/statistics_screen.dart
+++ b/lib/features/statistics/presentation/screens/statistics_screen.dart
@@ -328,7 +328,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                const Text(
+                Text(
                   context.l10n.evolution,
                   style: TextStyle(
                     fontSize: 18,
@@ -480,7 +480,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
     final data = provider.homeData;
 
     if (provider.isLoading && data == null) {
-      return const Padding(
+      return Padding(
         padding: EdgeInsets.symmetric(horizontal: 20),
         child: Center(child: CircularProgressIndicator()),
       );
@@ -491,7 +491,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
+          Text(
             context.l10n.appointmentsOverview,
             style: TextStyle(
               fontSize: 18,
@@ -586,7 +586,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
+          Text(
             context.l10n.recentHistory,
             style: TextStyle(
               fontSize: 18,
@@ -608,7 +608,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
               ],
             ),
             child: currentEntries.isEmpty
-                ? const Padding(
+                ? Padding(
                     padding: EdgeInsets.all(18),
                     child: Text(
                       context.l10n.noTrackingData,
@@ -837,7 +837,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                           ),
                         ),
                         const SizedBox(height: 16),
-                        const Text(
+                        Text(
                           context.l10n.treatment,
                           style: TextStyle(
                             fontWeight: FontWeight.w700,
@@ -876,7 +876,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                           },
                         ),
                         const SizedBox(height: 14),
-                        const Text(
+                        Text(
                           context.l10n.value,
                           style: TextStyle(
                             fontWeight: FontWeight.w700,
@@ -921,7 +921,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                           ),
                         ),
                         const SizedBox(height: 14),
-                        const Text(
+                        Text(
                           context.l10n.measureDate,
                           style: TextStyle(
                             fontWeight: FontWeight.w700,
@@ -992,7 +992,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                           ),
                         ),
                         const SizedBox(height: 14),
-                        const Text(
+                        Text(
                           context.l10n.notesOptional,
                           style: TextStyle(
                             fontWeight: FontWeight.w700,
@@ -1049,7 +1049,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                                     borderRadius: BorderRadius.circular(14),
                                   ),
                                 ),
-                                child: const Row(
+                                child: Row(
                                   mainAxisAlignment: MainAxisAlignment.center,
                                   children: [
                                     Icon(Icons.close_rounded, size: 18),
@@ -1094,7 +1094,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                                   ),
                                   elevation: 0,
                                 ),
-                                child: const Text(
+                                child: Text(
                                   context.l10n.save,
                                   style: TextStyle(fontWeight: FontWeight.w700),
                                 ),

--- a/lib/features/statistics/presentation/screens/statistics_screen.dart
+++ b/lib/features/statistics/presentation/screens/statistics_screen.dart
@@ -29,7 +29,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
     {'name': 'Tension', 'icon': Icons.favorite, 'color': Color(0xFFFF3B30), 'unit': 'mmHg'},
     {'name': 'Glycemie', 'icon': Icons.water_drop, 'color': Color(0xFF5856D6), 'unit': 'mg/dL'},
     {'name': 'Frequence', 'icon': Icons.monitor_heart, 'color': Color(0xFFFF2D55), 'unit': 'bpm'},
-    {'name': 'Temperature', 'icon': Icons.thermostat, 'color': Color(0xFFFF9500), 'unit': 'degC'},
+    {'name': 'Température', 'icon': Icons.thermostat, 'color': Color(0xFFFF9500), 'unit': '°C'},
   ];
 
   List<Map<String, dynamic>> _getChartData() {
@@ -1177,3 +1177,7 @@ class LineChartPainter extends CustomPainter {
   @override
   bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
 }
+
+
+
+

--- a/lib/features/statistics/presentation/screens/statistics_screen.dart
+++ b/lib/features/statistics/presentation/screens/statistics_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import '../../../home/presentation/providers/home_provider.dart';
 
@@ -12,23 +13,23 @@ class StatisticsScreen extends StatefulWidget {
 }
 
 class _StatisticsScreenState extends State<StatisticsScreen> {
-  String selectedPeriod = 'Semaine';
-  String selectedMetric = 'Tension';
+  String selectedPeriod = 'week';
+  String selectedMetric = 'bloodPressure';
 
-  final List<String> periods = ['Jour', 'Semaine', 'Mois', 'Annee'];
+  final List<String> periods = ['day', 'week', 'month', 'year'];
   final List<String> treatments = [
     'Metformine',
     'Insuline',
     'Amlodipine',
     'Levothyrox',
-    'Paracetamol',
+    'Paracétamol',
   ];
   final List<Map<String, dynamic>> measureEntries = [];
 
   final List<Map<String, dynamic>> metrics = [
-    {'name': 'Tension', 'icon': Icons.favorite, 'color': Color(0xFFFF3B30), 'unit': 'mmHg'},
-    {'name': 'Glycemie', 'icon': Icons.water_drop, 'color': Color(0xFF5856D6), 'unit': 'mg/dL'},
-    {'name': 'Frequence', 'icon': Icons.monitor_heart, 'color': Color(0xFFFF2D55), 'unit': 'bpm'},
+    {'id': 'bloodPressure', 'icon': Icons.favorite, 'color': Color(0xFFFF3B30), 'unit': 'mmHg'},
+    {'id': 'bloodGlucose', 'icon': Icons.water_drop, 'color': Color(0xFF5856D6), 'unit': 'mg/dL'},
+    {'id': 'heartRate', 'icon': Icons.monitor_heart, 'color': Color(0xFFFF2D55), 'unit': 'bpm'},
     {'name': 'Température', 'icon': Icons.thermostat, 'color': Color(0xFFFF9500), 'unit': '°C'},
   ];
 
@@ -36,21 +37,21 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
     final random = math.Random();
     final data = <Map<String, dynamic>>[];
 
-    final points = selectedPeriod == 'Jour'
+    final points = selectedPeriod == 'day'
         ? 24
-        : selectedPeriod == 'Semaine'
+        : selectedPeriod == 'week'
             ? 7
-            : selectedPeriod == 'Mois'
+            : selectedPeriod == 'month'
                 ? 30
                 : 12;
 
     for (int i = 0; i < points; i++) {
       double value;
-      if (selectedMetric == 'Tension') {
+      if (selectedMetric == 'bloodPressure') {
         value = 110 + random.nextDouble() * 30;
-      } else if (selectedMetric == 'Glycemie') {
+      } else if (selectedMetric == 'bloodGlucose') {
         value = 80 + random.nextDouble() * 40;
-      } else if (selectedMetric == 'Frequence') {
+      } else if (selectedMetric == 'heartRate') {
         value = 60 + random.nextDouble() * 40;
       } else {
         value = 36.5 + random.nextDouble() * 1.5;
@@ -70,6 +71,32 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
     final avg = values.reduce((a, b) => a + b) / values.length;
 
     return {'min': min, 'max': max, 'avg': avg};
+  }
+
+  String _metricLabel(BuildContext context, String id) {
+    switch (id) {
+      case 'bloodPressure':
+        return context.l10n.bloodPressure;
+      case 'bloodGlucose':
+        return context.l10n.bloodGlucose;
+      case 'heartRate':
+        return context.l10n.heartRate;
+      default:
+        return context.l10n.temperature;
+    }
+  }
+
+  String _periodLabel(BuildContext context, String id) {
+    switch (id) {
+      case 'day':
+        return context.l10n.day;
+      case 'week':
+        return context.l10n.week;
+      case 'month':
+        return context.l10n.month;
+      default:
+        return context.l10n.year;
+    }
   }
 
   @override
@@ -134,12 +161,12 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
       ),
       child: Row(
         children: [
-          const Expanded(
+          Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  'Statistiques',
+                  context.l10n.statisticsTitle,
                   style: TextStyle(
                     fontSize: 28,
                     fontWeight: FontWeight.bold,
@@ -148,7 +175,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                 ),
                 SizedBox(height: 4),
                 Text(
-                  'Suivez vos mesures de sante',
+                  context.l10n.trackYourHealth,
                   style: TextStyle(
                     fontSize: 14,
                     color: Color(0xFF8E8E93),
@@ -191,7 +218,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Text(
-                    period,
+                    _periodLabel(context, period),
                     textAlign: TextAlign.center,
                     style: TextStyle(
                       fontSize: 14,
@@ -217,10 +244,10 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
         itemCount: metrics.length,
         itemBuilder: (context, index) {
           final metric = metrics[index];
-          final isSelected = metric['name'] == selectedMetric;
+          final isSelected = metric['id'] == selectedMetric;
 
           return GestureDetector(
-            onTap: () => setState(() => selectedMetric = metric['name'] as String),
+            onTap: () => setState(() => selectedMetric = metric['id'] as String),
             child: Container(
               width: 95,
               margin: const EdgeInsets.only(right: 12),
@@ -257,7 +284,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                   ),
                   const SizedBox(height: 6),
                   Text(
-                    metric['name'] as String,
+                    _metricLabel(context, metric['id'] as String),
                     textAlign: TextAlign.center,
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
@@ -278,7 +305,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
 
   Widget _buildChartSection() {
     final data = _getChartData();
-    final metric = metrics.firstWhere((m) => m['name'] == selectedMetric);
+    final metric = metrics.firstWhere((m) => m['id'] == selectedMetric);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 20),
@@ -302,7 +329,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 const Text(
-                  'Evolution',
+                  context.l10n.evolution,
                   style: TextStyle(
                     fontSize: 18,
                     fontWeight: FontWeight.w700,
@@ -349,7 +376,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
 
   Widget _buildStatisticsCards() {
     final stats = _getStatistics();
-    final metric = metrics.firstWhere((m) => m['name'] == selectedMetric);
+    final metric = metrics.firstWhere((m) => m['id'] == selectedMetric);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 20),
@@ -465,7 +492,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const Text(
-            'Resume dashboard',
+            context.l10n.appointmentsOverview,
             style: TextStyle(
               fontSize: 18,
               fontWeight: FontWeight.w700,
@@ -477,7 +504,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
             children: [
               Expanded(
                 child: _buildStatCard(
-                  'RDV/mois',
+                  context.l10n.appointmentsPerMonth,
                   '${data?.appointmentsThisMonth ?? 0}',
                   '',
                   const Color(0xFF007AFF),
@@ -487,7 +514,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
               const SizedBox(width: 12),
               Expanded(
                 child: _buildStatCard(
-                  'Terminés',
+                  context.l10n.completed,
                   '${data?.completedAppointments ?? 0}',
                   '',
                   const Color(0xFF34C759),
@@ -501,7 +528,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
             children: [
               Expanded(
                 child: _buildStatCard(
-                  'En attente',
+                  context.l10n.pending,
                   '${data?.pendingAppointments ?? 0}',
                   '',
                   const Color(0xFFFF9500),
@@ -511,7 +538,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
               const SizedBox(width: 12),
               Expanded(
                 child: _buildStatCard(
-                  'Adhérence',
+                  context.l10n.adherence,
                   '${data?.medicationAdherenceRate ?? 0}',
                   '%',
                   const Color(0xFF5856D6),
@@ -533,7 +560,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
         child: ElevatedButton.icon(
           onPressed: _showAddMeasureDialog,
           icon: const Icon(Icons.add_chart),
-          label: const Text('Ajouter une donnee'),
+          label: Text(context.l10n.addData),
           style: ElevatedButton.styleFrom(
             backgroundColor: const Color(0xFF34C759),
             foregroundColor: Colors.white,
@@ -548,7 +575,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
   }
 
   Widget _buildHistorySection() {
-    final metric = metrics.firstWhere((m) => m['name'] == selectedMetric);
+    final metric = metrics.firstWhere((m) => m['id'] == selectedMetric);
     final currentEntries = measureEntries
         .where((entry) => entry['metric'] == selectedMetric)
         .toList()
@@ -560,7 +587,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const Text(
-            'Historique recent',
+            context.l10n.recentHistory,
             style: TextStyle(
               fontSize: 18,
               fontWeight: FontWeight.w700,
@@ -584,7 +611,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                 ? const Padding(
                     padding: EdgeInsets.all(18),
                     child: Text(
-                      'Aucune donnee de suivi pour cette metrique.',
+                      context.l10n.noTrackingData,
                       style: TextStyle(
                         fontSize: 14,
                         color: Color(0xFF8E8E93),
@@ -710,7 +737,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
   }
 
   void _showAddMeasureDialog() {
-    final metric = metrics.firstWhere((m) => m['name'] == selectedMetric);
+    final metric = metrics.firstWhere((m) => m['id'] == selectedMetric);
     final metricColor = metric['color'] as Color;
     final metricIcon = metric['icon'] as IconData;
     final valueController = TextEditingController();
@@ -786,8 +813,8 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                                 child: Column(
                                   crossAxisAlignment: CrossAxisAlignment.start,
                                   children: [
-                                    const Text(
-                                      'Nouvelle donnee de suivi',
+                                    Text(
+                                      context.l10n.newTrackingData,
                                       style: TextStyle(
                                         fontSize: 17,
                                         fontWeight: FontWeight.w800,
@@ -796,7 +823,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                                     ),
                                     const SizedBox(height: 2),
                                     Text(
-                                      '${metric['name']} - ${metric['unit']}',
+                                      '${_metricLabel(context, metric['id'] as String)} - ${metric['unit']}',
                                       style: TextStyle(
                                         fontSize: 13,
                                         color: metricColor.withValues(alpha: 0.85),
@@ -811,7 +838,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                         ),
                         const SizedBox(height: 16),
                         const Text(
-                          'Traitement',
+                          context.l10n.treatment,
                           style: TextStyle(
                             fontWeight: FontWeight.w700,
                             color: Color(0xFF1D1D1F),
@@ -850,7 +877,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                         ),
                         const SizedBox(height: 14),
                         const Text(
-                          'Valeur',
+                          context.l10n.value,
                           style: TextStyle(
                             fontWeight: FontWeight.w700,
                             color: Color(0xFF1D1D1F),
@@ -872,7 +899,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                             controller: valueController,
                             keyboardType: const TextInputType.numberWithOptions(decimal: true),
                             decoration: InputDecoration(
-                              hintText: 'Ex: 120',
+                              hintText: context.l10n.exampleValue,
                               prefixIcon: Icon(metricIcon, color: metricColor),
                               suffixText: metric['unit'] as String,
                               filled: true,
@@ -895,7 +922,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                         ),
                         const SizedBox(height: 14),
                         const Text(
-                          'Date de mesure',
+                          context.l10n.measureDate,
                           style: TextStyle(
                             fontWeight: FontWeight.w700,
                             color: Color(0xFF1D1D1F),
@@ -966,7 +993,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                         ),
                         const SizedBox(height: 14),
                         const Text(
-                          'Note (optionnel)',
+                          context.l10n.notesOptional,
                           style: TextStyle(
                             fontWeight: FontWeight.w700,
                             color: Color(0xFF1D1D1F),
@@ -988,7 +1015,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                             controller: noteController,
                             maxLines: 3,
                             decoration: InputDecoration(
-                              hintText: 'Contexte, symptomes, ressenti...',
+                              hintText: context.l10n.contextField,
                               filled: true,
                               fillColor: Colors.white,
                               contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
@@ -1028,7 +1055,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                                     Icon(Icons.close_rounded, size: 18),
                                     SizedBox(width: 6),
                                     Text(
-                                      'Annuler',
+                                      context.l10n.cancel,
                                       style: TextStyle(fontWeight: FontWeight.w700),
                                     ),
                                   ],
@@ -1043,7 +1070,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                                     valueController.text.trim().replaceAll(',', '.'),
                                   );
                                   if (parsedValue == null) {
-                                    _showSnackBar('Valeur numerique invalide.');
+                                    _showSnackBar(context.l10n.valueFormatInvalid);
                                     return;
                                   }
                                   setState(() {
@@ -1056,7 +1083,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                                     });
                                   });
                                   Navigator.pop(context);
-                                  _showSnackBar('Donnee enregistree.');
+                                  _showSnackBar(context.l10n.dataSavedMessage);
                                 },
                                 style: ElevatedButton.styleFrom(
                                   minimumSize: const Size.fromHeight(50),
@@ -1068,7 +1095,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                                   elevation: 0,
                                 ),
                                 child: const Text(
-                                  'Enregistrer',
+                                  context.l10n.save,
                                   style: TextStyle(fontWeight: FontWeight.w700),
                                 ),
                               ),
@@ -1165,7 +1192,3 @@ class LineChartPainter extends CustomPainter {
   @override
   bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
 }
-
-
-
-

--- a/lib/features/statistics/presentation/screens/statistics_screen.dart
+++ b/lib/features/statistics/presentation/screens/statistics_screen.dart
@@ -384,7 +384,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
         children: [
           Expanded(
             child: _buildStatCard(
-              'Minimum',
+              context.l10n.minimum,
               stats['min']!.toStringAsFixed(1),
               metric['unit'] as String,
               const Color(0xFF5856D6),
@@ -394,7 +394,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
           const SizedBox(width: 12),
           Expanded(
             child: _buildStatCard(
-              'Moyenne',
+              context.l10n.average,
               stats['avg']!.toStringAsFixed(1),
               metric['unit'] as String,
               const Color(0xFF34C759),
@@ -404,7 +404,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
           const SizedBox(width: 12),
           Expanded(
             child: _buildStatCard(
-              'Maximum',
+              context.l10n.maximum,
               stats['max']!.toStringAsFixed(1),
               metric['unit'] as String,
               const Color(0xFFFF3B30),
@@ -623,6 +623,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                     children: List.generate(currentEntries.length, (index) {
                       final entry = currentEntries[index];
                       return _buildHistoryItem(
+                        context,
                         entry['value'].toStringAsFixed(1),
                         metric['unit'] as String,
                         entry['date'] as DateTime,
@@ -639,6 +640,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
   }
 
   Widget _buildHistoryItem(
+    BuildContext context,
     String value,
     String unit,
     DateTime date,
@@ -648,7 +650,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
   }) {
     final now = DateTime.now();
     final isToday = date.year == now.year && date.month == now.month && date.day == now.day;
-    final dateStr = isToday ? "Aujourd'hui" : "${date.day}/${date.month}/${date.year}";
+    final dateStr = isToday ? context.l10n.today : "${date.day}/${date.month}/${date.year}";
     final timeStr = "${date.hour.toString().padLeft(2, '0')}:${date.minute.toString().padLeft(2, '0')}";
 
     return Column(

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class AppLocalizations {
+  const AppLocalizations(this.locale);
+
+  final Locale locale;
+
+  static const supportedLocales = <Locale>[
+    Locale('fr'),
+    Locale('en'),
+  ];
+
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
+
+  static AppLocalizations of(BuildContext context) {
+    final localizations = Localizations.of<AppLocalizations>(context, AppLocalizations);
+    assert(localizations != null, 'AppLocalizations is not available in the widget tree.');
+    return localizations ?? const AppLocalizations(Locale('fr'));
+  }
+
+  bool get isFrench => locale.languageCode == 'fr';
+
+  String tr({required String fr, required String en}) => isFrench ? fr : en;
+
+  String helloUser(String name) => tr(fr: 'Bonjour, $name', en: 'Hello, $name');
+
+  String genericError(String message) => tr(
+        fr: 'Erreur: $message',
+        en: 'Error: $message',
+      );
+
+  String uploadFailed(String message) => tr(
+        fr: 'Echec du televersement: $message',
+        en: 'Upload failed: $message',
+      );
+
+  String filesUploaded(int count) => tr(
+        fr: '$count fichier(s) televerse(s)',
+        en: '$count file(s) uploaded',
+      );
+
+  String fileTooLarge(String fileName) => tr(
+        fr: '$fileName depasse la limite de 25 Mo',
+        en: '$fileName exceeds 25 MB limit',
+      );
+
+  String failedToDownload(String message) => tr(
+        fr: 'Echec du telechargement: $message',
+        en: 'Failed to download: $message',
+      );
+
+  String deleteDocumentConfirm(String fileName) => tr(
+        fr: 'Supprimer "$fileName" ? Cette action est irreversible.',
+        en: 'Delete "$fileName"? This action cannot be undone.',
+      );
+
+  String failedToDelete(String message) => tr(
+        fr: 'Echec de la suppression: $message',
+        en: 'Failed to delete: $message',
+      );
+
+  String pageNotFound(String uri) => tr(
+        fr: 'Page introuvable: $uri',
+        en: 'Page not found: $uri',
+      );
+
+  String invalidNumericValue() => tr(
+        fr: 'Valeur numerique invalide.',
+        en: 'Invalid numeric value.',
+      );
+
+  String dataSaved() => tr(
+        fr: 'Donnee enregistree.',
+        en: 'Data saved.',
+      );
+
+  String get retry => tr(fr: 'Reessayer', en: 'Retry');
+  String get cancel => tr(fr: 'Annuler', en: 'Cancel');
+  String get save => tr(fr: 'Enregistrer', en: 'Save');
+  String get delete => tr(fr: 'Supprimer', en: 'Delete');
+  String get edit => tr(fr: 'Modifier', en: 'Edit');
+  String get add => tr(fr: 'Ajouter', en: 'Add');
+  String get back => tr(fr: 'Retour', en: 'Back');
+  String get loading => tr(fr: 'Chargement...', en: 'Loading...');
+  String get email => tr(fr: 'Email', en: 'Email');
+  String get password => tr(fr: 'Mot de passe', en: 'Password');
+  String get documents => tr(fr: 'Documents', en: 'Documents');
+  String get settings => tr(fr: 'Parametres', en: 'Settings');
+  String get language => tr(fr: 'Langue', en: 'Language');
+  String get english => tr(fr: 'Anglais', en: 'English');
+  String get logout => tr(fr: 'Deconnexion', en: 'Logout');
+  String get cancelAction => tr(fr: 'Annuler', en: 'Cancel');
+  String get doctor => tr(fr: 'Medecin', en: 'Doctor');
+  String get patient => tr(fr: 'Patient', en: 'Patient');
+  String get search => tr(fr: 'Recherche', en: 'Search');
+  String get messages => tr(fr: 'Messages', en: 'Messages');
+  String get calendar => tr(fr: 'Calendrier', en: 'Calendar');
+  String get schedule => tr(fr: 'Programme', en: 'Schedule');
+  String get lists => tr(fr: 'Liste', en: 'Lists');
+  String get upcoming => tr(fr: 'A venir', en: 'Upcoming');
+  String get past => tr(fr: 'Passes', en: 'Past');
+  String get cancelled => tr(fr: 'Annules', en: 'Cancelled');
+  String get total => tr(fr: 'Total', en: 'Total');
+  String get active => tr(fr: 'Actifs', en: 'Active');
+  String get inactive => tr(fr: 'Inactifs', en: 'Inactive');
+  String get all => tr(fr: 'Tous', en: 'All');
+  String get myDocuments => tr(fr: 'Mes documents', en: 'My Documents');
+  String get yourDocuments => tr(fr: 'Vos documents', en: 'Your Documents');
+  String get uploading => tr(fr: 'Televersement...', en: 'Uploading...');
+  String get uploadDocuments => tr(fr: 'Televerser des documents', en: 'Upload Documents');
+  String get noDocumentsYet => tr(fr: 'Aucun document pour le moment', en: 'No documents yet');
+  String get uploadFirstDocument => tr(
+        fr: 'Televersez votre premier document pour commencer',
+        en: 'Upload your first document to get started',
+      );
+  String get deleteDocumentTitle => tr(fr: 'Supprimer le document', en: 'Delete Document');
+  String get documentDeleted => tr(fr: 'Document supprime', en: 'Document deleted');
+  String get noAvailableSlots => tr(
+        fr: 'Aucun creneau disponible pour cette date.',
+        en: 'No available slots for this date.',
+      );
+  String get bookAppointment => tr(fr: 'Prendre rendez-vous', en: 'Book an appointment');
+  String get confirmAppointment => tr(fr: 'Confirmer le rendez-vous', en: 'Confirm appointment');
+  String get addMedication => tr(fr: 'Ajouter un medicament', en: 'Add medication');
+  String get addToPillbox => tr(fr: 'Ajouter au pilulier', en: 'Add to pillbox');
+  String get medicationPlan => tr(fr: 'Plan de medicaments', en: 'Medication Plan');
+  String get medicationNotFound => tr(fr: 'Medicament introuvable', en: 'Medication not found');
+  String get instructions => tr(fr: 'Instructions', en: 'Instructions');
+  String get quantity => tr(fr: 'Quantite', en: 'Quantity');
+  String get unit => tr(fr: 'Unite', en: 'Unit');
+  String get notesOptional => tr(fr: 'Notes (optionnel)', en: 'Notes (optional)');
+  String get momentOfDay => tr(fr: 'Moment de la journee', en: 'Time of day');
+  String get timeOfIntake => tr(fr: 'Heure de prise', en: 'Intake time');
+  String get addSchedule => tr(fr: 'Ajouter un horaire', en: 'Add schedule');
+  String get modifySchedule => tr(fr: 'Modifier l\'horaire', en: 'Edit schedule');
+  String get scheduleTimes => tr(fr: 'Horaires de prise', en: 'Intake times');
+  String get actions => tr(fr: 'Actions', en: 'Actions');
+  String get frequency => tr(fr: 'Frequence', en: 'Frequency');
+  String get start => tr(fr: 'Debut', en: 'Start');
+  String get end => tr(fr: 'Fin', en: 'End');
+  String get description => tr(fr: 'Description', en: 'Description');
+  String get markAsTaken => tr(fr: 'Marquer comme pris', en: 'Mark as taken');
+  String get skip => tr(fr: 'Ignorer', en: 'Skip');
+  String get approveAll => tr(fr: 'Tout approuver', en: 'Approve all');
+  String get rejectAll => tr(fr: 'Tout refuser', en: 'Reject all');
+  String get soonAvailable => tr(fr: 'Bientot disponible...', en: 'Coming soon...');
+  String get chooseSpecialty => tr(fr: 'Choisir une specialite', en: 'Choose a specialty');
+  String get specialties => tr(fr: 'Specialites', en: 'Specialties');
+  String get askDocAi => tr(fr: 'Posez votre question a DocAI', en: 'Ask DocAI a question');
+  String get docAiAssistant => tr(fr: 'Assistant DocAI', en: 'DocAI Assistant');
+  String get viewAll => tr(fr: 'Voir tout', en: 'View All');
+  String get recentActivity => tr(fr: 'Activite recente', en: 'Recent Activity');
+  String get startChatDocAi => tr(fr: 'Commencer un chat avec DocAI', en: 'Start a chat with DocAI');
+}
+
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => AppLocalizations.supportedLocales
+      .any((supported) => supported.languageCode == locale.languageCode);
+
+  @override
+  Future<AppLocalizations> load(Locale locale) {
+    return SynchronousFuture(AppLocalizations(locale));
+  }
+
+  @override
+  bool shouldReload(covariant LocalizationsDelegate<AppLocalizations> old) => false;
+}
+
+extension AppLocalizationsContext on BuildContext {
+  AppLocalizations get l10n => AppLocalizations.of(this);
+}

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -17,14 +17,20 @@ class AppLocalizations {
   static AppLocalizations of(BuildContext context) {
     final localizations =
         Localizations.of<AppLocalizations>(context, AppLocalizations);
-    assert(localizations != null,
-        'AppLocalizations is not available in the widget tree.');
-    return localizations ?? const AppLocalizations(Locale('fr'));
+    assert(
+      localizations != null,
+      'AppLocalizations is not available in the widget tree.',
+    );
+    if (localizations == null) {
+      throw StateError('AppLocalizations is not available in the widget tree.');
+    }
+    return localizations;
   }
 
   bool get isFrench => locale.languageCode == 'fr';
 
-  String tr({required String fr, required String en}) => isFrench ? fr : en;
+  String tr({required String fr, required String en}) =>
+      isFrench ? fr : en;
 
   String helloUser(String name) => tr(fr: 'Bonjour, $name', en: 'Hello, $name');
   String get hello => tr(fr: 'Bonjour', en: 'Hello');
@@ -82,22 +88,197 @@ class AppLocalizations {
   String get retry => tr(fr: 'Réessayer', en: 'Retry');
   String get cancel => tr(fr: 'Annuler', en: 'Cancel');
   String get save => tr(fr: 'Enregistrer', en: 'Save');
+  String get saveChanges => tr(fr: 'Enregistrer les modifications', en: 'Save changes');
   String get delete => tr(fr: 'Supprimer', en: 'Delete');
   String get edit => tr(fr: 'Modifier', en: 'Edit');
   String get add => tr(fr: 'Ajouter', en: 'Add');
   String get back => tr(fr: 'Retour', en: 'Back');
-  String get loading => tr(fr: 'Chargement…', en: 'Loading...');
+  String get loading => tr(fr: 'Chargement...', en: 'Loading...');
   String get email => tr(fr: 'Email', en: 'Email');
   String get password => tr(fr: 'Mot de passe', en: 'Password');
+  String get connectToContinue =>
+      tr(fr: 'Connectez-vous pour continuer', en: 'Sign in to continue');
+  String get forgotPassword =>
+      tr(fr: 'Mot de passe oublié?', en: 'Forgot password?');
+  String get emailSentSuccess =>
+      tr(fr: 'Email envoyé avec succès!', en: 'Email sent successfully!');
+  String get emailSent => tr(fr: 'Email envoyé !', en: 'Email sent!');
+  String get personalInformation =>
+      tr(fr: 'Informations personnelles', en: 'Personal information');
+  String get howShouldWeCallYou =>
+      tr(fr: 'Comment devons-nous vous appeler ?', en: 'How should we address you?');
+  String get yourEmail => tr(fr: 'Votre email', en: 'Your email');
+  String get weWillUseItToConnect =>
+      tr(fr: 'Nous l’utiliserons pour vous connecter', en: 'We will use it to sign you in');
+  String get secureYourAccount =>
+      tr(fr: 'Sécurisez votre compte', en: 'Secure your account');
+  String get chooseStrongPassword =>
+      tr(fr: 'Choisissez un mot de passe fort', en: 'Choose a strong password');
+  String get confirmPassword =>
+      tr(fr: 'Confirmer le mot de passe', en: 'Confirm password');
+  String get invalidCredentials =>
+      tr(fr: 'Email ou mot de passe incorrect', en: 'Invalid email or password');
+  String get invalidDoctor =>
+      tr(fr: 'Médecin invalide', en: 'Invalid doctor');
+  String get createAppointmentFailed =>
+      tr(fr: 'Erreur lors de la création du rendez-vous', en: 'Failed to create appointment');
+  String get pleaseTryAgain =>
+      tr(fr: 'Veuillez réessayer.', en: 'Please try again.');
+  String get registrationFailed =>
+      tr(fr: 'Échec de l\'inscription. Veuillez réessayer.', en: 'Registration failed. Please try again.');
+  String get firstName => tr(fr: 'Prénom', en: 'First name');
+  String get lastName => tr(fr: 'Nom', en: 'Last name');
+  String get phone => tr(fr: 'Téléphone', en: 'Phone');
+  String get dateOfBirth => tr(fr: 'Date de naissance', en: 'Date of birth');
+  String get address => tr(fr: 'Adresse', en: 'Address');
+  String get gender => tr(fr: 'Genre', en: 'Gender');
+  String get requiredField =>
+      tr(fr: 'Champ requis', en: 'Required field');
+  String get pleaseEnterFirstName =>
+      tr(fr: 'Veuillez saisir votre prénom', en: 'Please enter your first name');
+  String get pleaseEnterLastName =>
+      tr(fr: 'Veuillez saisir votre nom', en: 'Please enter your last name');
+  String get pleaseEnterEmail =>
+      tr(fr: 'Veuillez saisir votre email', en: 'Please enter your email');
+  String get pleaseEnterValidEmail =>
+      tr(fr: 'Veuillez saisir un email valide', en: 'Please enter a valid email');
+  String get pleaseEnterPhone =>
+      tr(fr: 'Veuillez saisir votre numéro de téléphone', en: 'Please enter your phone number');
+  String get male => tr(fr: 'Homme', en: 'Male');
+  String get female => tr(fr: 'Femme', en: 'Female');
+  String get other => tr(fr: 'Autre', en: 'Other');
+  String get selectGender =>
+      tr(fr: 'Veuillez sélectionner votre genre', en: 'Please select your gender');
+  String get profileUpdatedSuccessfully =>
+      tr(fr: 'Profil mis à jour avec succès !', en: 'Profile updated successfully!');
+  String get profileUpdateFailed =>
+      tr(fr: 'Échec de la mise à jour du profil', en: 'Profile update failed');
+  String get changeProfilePhoto =>
+      tr(fr: 'Fonction de changement de photo', en: 'Profile photo change feature');
+  String get changePassword =>
+      tr(fr: 'Changer le mot de passe', en: 'Change password');
+  String get myAccount => tr(fr: 'Mon compte', en: 'My Account');
+  String get accountInformation =>
+      tr(fr: 'Informations du compte', en: 'Account information');
+  String get notifications => tr(fr: 'Notifications', en: 'Notifications');
+  String get privacySecurity =>
+      tr(fr: 'Confidentialité et sécurité', en: 'Privacy and security');
+  String get helpSupport =>
+      tr(fr: 'Aide et support', en: 'Help and support');
+  String get about => tr(fr: 'À propos', en: 'About');
+  String get security => tr(fr: 'Sécurité', en: 'Security');
+  String get language => tr(fr: 'Langue', en: 'Language');
+  String get french => tr(fr: 'Français', en: 'French');
+  String get english => tr(fr: 'Anglais', en: 'English');
   String get documents => tr(fr: 'Documents', en: 'Documents');
   String get settings => tr(fr: 'Paramètres', en: 'Settings');
-  String get language => tr(fr: 'Langue', en: 'Language');
-  String get english => tr(fr: 'Anglais', en: 'English');
   String get logout => tr(fr: 'Déconnexion', en: 'Logout');
   String get cancelAction => tr(fr: 'Annuler', en: 'Cancel');
   String get doctor => tr(fr: 'Médecin', en: 'Doctor');
   String get patient => tr(fr: 'Patient', en: 'Patient');
   String get search => tr(fr: 'Recherche', en: 'Search');
+  String get writeMessage => tr(fr: 'Tapez un message...', en: 'Type a message...');
+  String get searchMedication =>
+      tr(fr: 'Rechercher un médicament', en: 'Search for a medication');
+  String get minimum3Characters =>
+      tr(fr: 'Minimum 3 caractères', en: 'Minimum 3 characters');
+  String get noResultsFound =>
+      tr(fr: 'Aucun résultat. Essayez un nom de molécule (ex: paracétamol).', en: 'No results. Try a molecule name (e.g. paracetamol).');
+  String minutesAgo(int minutes) =>
+      tr(fr: 'Il y a $minutes min', en: '$minutes min ago');
+  String hoursAgo(int hours) =>
+      tr(fr: 'Il y a $hours h', en: '$hours h ago');
+  String get yesterday => tr(fr: 'Hier', en: 'Yesterday');
+  String formattedDate(String date) => tr(fr: date, en: date);
+  String get searchDoctor =>
+      tr(fr: 'Rechercher un médecin...', en: 'Search for a doctor...');
+  String get consultDoctorsToBook =>
+      tr(fr: 'Consultez la liste des médecins pour prendre rendez-vous.', en: 'Browse the doctor list to book an appointment.');
+  String get noDoctorsAvailable =>
+      tr(fr: 'Aucun médecin disponible', en: 'No doctors available');
+  String get noAvailableSlotsMessage =>
+      tr(fr: 'Aucun créneau disponible pour cette date.', en: 'No available slots for this date.');
+  String get confirmBooking => tr(fr: 'Confirmer le rendez-vous', en: 'Confirm appointment');
+  String get myAppointments => tr(fr: 'Mes rendez-vous', en: 'My appointments');
+  String get noUpcomingAppointments =>
+      tr(fr: 'Aucun rendez-vous à venir', en: 'No upcoming appointments');
+  String get noPastAppointments =>
+      tr(fr: 'Aucun rendez-vous passé', en: 'No past appointments');
+  String get noCancelledAppointments =>
+      tr(fr: 'Aucun rendez-vous annulé', en: 'No cancelled appointments');
+  String get bookFromDoctorsList =>
+      tr(fr: 'Prenez rendez-vous depuis la liste des médecins.', en: 'Book an appointment from the doctor list.');
+  String get pastConsultationsWillAppearHere =>
+      tr(fr: 'Vos consultations terminées apparaîtront ici.', en: 'Your completed consultations will appear here.');
+  String get cancelledAppointmentsWillAppearHere =>
+      tr(fr: 'Les rendez-vous annulés apparaîtront ici.', en: 'Cancelled appointments will appear here.');
+  String get appointmentStatus =>
+      tr(fr: 'Statut du rendez-vous', en: 'Appointment status');
+  String get requestSent =>
+      tr(fr: 'Demande envoyée !', en: 'Request sent!');
+  String get waitingConfirmation =>
+      tr(fr: 'En attente de confirmation', en: 'Waiting for confirmation');
+  String get appointmentDetails =>
+      tr(fr: 'Détails du rendez-vous', en: 'Appointment details');
+  String get dateLabel => tr(fr: 'Date', en: 'Date');
+  String get timeLabel => tr(fr: 'Heure', en: 'Time');
+  String get addressLabel => tr(fr: 'Adresse', en: 'Address');
+  String get andNow => tr(fr: 'Et maintenant ?', en: 'And now?');
+  String get youWillReceiveNotification => tr(
+        fr: 'Vous recevrez une notification une fois que le médecin aura confirmé votre demande de rendez-vous.',
+        en: 'You will receive a notification once the doctor confirms your appointment request.',
+      );
+  String get backToHome => tr(fr: "Retour à l'accueil", en: 'Back to home');
+  String get seeMyAppointments => tr(fr: 'Voir mes rendez-vous', en: 'See my appointments');
+  String get statisticsTitle => tr(fr: 'Statistiques', en: 'Statistics');
+  String get trackYourHealth =>
+      tr(fr: 'Suivez vos mesures de santé', en: 'Track your health measurements');
+  String get evolution => tr(fr: 'Évolution', en: 'Trend');
+  String get day => tr(fr: 'Jour', en: 'Day');
+  String get week => tr(fr: 'Semaine', en: 'Week');
+  String get month => tr(fr: 'Mois', en: 'Month');
+  String get year => tr(fr: 'Année', en: 'Year');
+  String get bloodPressure => tr(fr: 'Tension', en: 'Blood pressure');
+  String get bloodGlucose => tr(fr: 'Glycémie', en: 'Blood glucose');
+  String get heartRate => tr(fr: 'Fréquence cardiaque', en: 'Heart rate');
+  String get temperature => tr(fr: 'Température', en: 'Temperature');
+  String get newTrackingData =>
+      tr(fr: 'Nouvelle donnée de suivi', en: 'New tracking data');
+  String get treatment => tr(fr: 'Traitement', en: 'Treatment');
+  String get value => tr(fr: 'Valeur', en: 'Value');
+  String get measureDate => tr(fr: 'Date de mesure', en: 'Measurement date');
+  String get noteOptionnel =>
+      tr(fr: 'Note (optionnel)', en: 'Note (optional)');
+  String get contextField =>
+      tr(fr: 'Contexte, symptômes, ressenti...', en: 'Context, symptoms, feeling...');
+  String get addMeasure => tr(fr: 'Ajouter une donnée', en: 'Add measurement');
+  String get today => tr(fr: "Aujourd'hui", en: 'Today');
+  String get confirmed => tr(fr: 'Confirmé', en: 'Confirmed');
+  String get appName => tr(fr: 'CoreVia Mobile', en: 'CoreVia Mobile');
+  String get exampleValue => tr(fr: 'Ex: 120', en: 'Ex: 120');
+  String get editing => tr(fr: 'Modifier', en: 'Edit');
+  String get appointmentDate => tr(fr: 'Date', en: 'Date');
+  String get appointmentTime => tr(fr: 'Heure', en: 'Time');
+  String get appointmentAddress => tr(fr: 'Adresse', en: 'Address');
+  String get myAppointmentsTitle => tr(fr: 'Mes rendez-vous', en: 'My appointments');
+  String get appointmentsOverview =>
+      tr(fr: 'Résumé du tableau de bord', en: 'Dashboard summary');
+  String get appointmentsPerMonth =>
+      tr(fr: 'RDV/mois', en: 'Appointments/month');
+  String get completed => tr(fr: 'Terminés', en: 'Completed');
+  String get pending => tr(fr: 'En attente', en: 'Pending');
+  String get adherence => tr(fr: 'Adhérence', en: 'Adherence');
+  String get average => tr(fr: 'Moyenne', en: 'Average');
+  String get maximum => tr(fr: 'Maximum', en: 'Maximum');
+  String get minimum => tr(fr: 'Minimum', en: 'Minimum');
+  String get addData => tr(fr: 'Ajouter une donnée', en: 'Add data');
+  String get recentHistory => tr(fr: 'Historique récent', en: 'Recent history');
+  String get noTrackingData =>
+      tr(fr: 'Aucune donnée de suivi pour cette métrique.', en: 'No tracking data for this metric.');
+  String get valueFormatInvalid =>
+      tr(fr: 'Valeur numérique invalide.', en: 'Invalid numeric value.');
+  String get dataSavedMessage =>
+      tr(fr: 'Donnée enregistrée.', en: 'Data saved.');
   String get messages => tr(fr: 'Messages', en: 'Messages');
   String get calendar => tr(fr: 'Calendrier', en: 'Calendar');
   String get schedule => tr(fr: 'Programme', en: 'Schedule');
@@ -109,12 +290,13 @@ class AppLocalizations {
   String get active => tr(fr: 'Actifs', en: 'Active');
   String get inactive => tr(fr: 'Inactifs', en: 'Inactive');
   String get all => tr(fr: 'Tous', en: 'All');
+  String get loadMore => tr(fr: 'Charger plus', en: 'Load more');
   String get myDocuments => tr(fr: 'Mes documents', en: 'My Documents');
   String get yourDocuments => tr(fr: 'Vos documents', en: 'Your Documents');
-  String get uploading => tr(fr: 'Téléversement…', en: 'Uploading...');
+  String get uploading => tr(fr: 'Téléversement...', en: 'Uploading...');
   String get uploadingTitle => tr(fr: 'Téléversement', en: 'Uploading');
   String get uploadDocuments =>
-      tr(fr: 'Téléverser des documents', en: 'Upload Documents');
+      tr(fr: 'Téléverser des documents', en: 'Upload documents');
   String get noDocumentsYet =>
       tr(fr: 'Aucun document pour le moment', en: 'No documents yet');
   String get uploadFirstDocument => tr(
@@ -122,7 +304,7 @@ class AppLocalizations {
         en: 'Upload your first document to get started',
       );
   String get deleteDocumentTitle =>
-      tr(fr: 'Supprimer le document', en: 'Delete Document');
+      tr(fr: 'Supprimer le document', en: 'Delete document');
   String get documentDeleted =>
       tr(fr: 'Document supprimé', en: 'Document deleted');
   String confirmUploadFailed(String message) => tr(
@@ -140,36 +322,79 @@ class AppLocalizations {
   String get addMedication =>
       tr(fr: 'Ajouter un médicament', en: 'Add medication');
   String get addMedicationsWithSchedules => tr(
-      fr: 'Ajoutez des médicaments avec des horaires',
-      en: 'Add medications with schedules');
+        fr: 'Ajoutez des médicaments avec des horaires',
+        en: 'Add medications with schedules',
+      );
   String get addMedicationShort =>
       tr(fr: 'Ajouter un médicament', en: 'Add medication');
   String get addToPillbox =>
       tr(fr: 'Ajouter au pilulier', en: 'Add to pillbox');
   String get medicationPlan =>
-      tr(fr: 'Plan de médicaments', en: 'Medication Plan');
+      tr(fr: 'Plan de médicaments', en: 'Medication plan');
   String get medicationNotFound =>
       tr(fr: 'Médicament introuvable', en: 'Medication not found');
+  String get medicationDetails =>
+      tr(fr: 'Détail du médicament', en: 'Medication details');
+  String get information => tr(fr: 'Informations', en: 'Information');
+  String get dosage => tr(fr: 'Posologie', en: 'Dosage');
+  String get notProvided =>
+      tr(fr: 'Non renseigné', en: 'Not provided');
+  String get noInstruction =>
+      tr(fr: 'Aucune instruction', en: 'No instructions');
+  String get activeSubstances =>
+      tr(fr: 'Substances actives', en: 'Active ingredients');
+  String get noScheduleConfigured =>
+      tr(fr: 'Aucun horaire configuré', en: 'No schedule configured');
+  String get addScheduleToTrack =>
+      tr(fr: 'Ajoutez un horaire pour suivre vos prises', en: 'Add a schedule to track your doses');
+  String get disableMedication =>
+      tr(fr: 'Désactiver le médicament', en: 'Disable medication');
+  String get enableMedication =>
+      tr(fr: 'Réactiver le médicament', en: 'Enable medication');
+  String get editMedication =>
+      tr(fr: 'Modifier le médicament', en: 'Edit medication');
+  String get deleteMedication =>
+      tr(fr: 'Supprimer le médicament', en: 'Delete medication');
+  String get confirmDeleteMedication =>
+      tr(fr: 'Supprimer ce médicament ?', en: 'Delete this medication?');
+  String get medicationDeleteWarning => tr(
+        fr: 'Le médicament et tous ses horaires seront supprimés définitivement.',
+        en: 'The medication and all its schedules will be permanently deleted.',
+      );
+  String get deleteScheduleConfirm =>
+      tr(fr: 'Supprimer cet horaire ?', en: 'Delete this schedule?');
+  String get irreversibleAction =>
+      tr(fr: 'Cette action est irréversible.', en: 'This action cannot be undone.');
+  String get noDetails =>
+      tr(fr: 'Aucun détail', en: 'No details');
   String get instructions => tr(fr: 'Instructions', en: 'Instructions');
   String get quantity => tr(fr: 'Quantité', en: 'Quantity');
   String get unit => tr(fr: 'Unité', en: 'Unit');
+  String get unitExamples =>
+      tr(fr: 'Unité (mg, ml...)', en: 'Unit (mg, ml...)');
   String get notesOptional =>
       tr(fr: 'Notes (optionnel)', en: 'Notes (optional)');
-  String get momentOfDay => tr(fr: 'Moment de la journée', en: 'Time of day');
+  String get momentOfDay =>
+      tr(fr: 'Moment de la journée', en: 'Time of day');
   String get timeOfIntake => tr(fr: 'Heure de prise', en: 'Intake time');
-  String get addSchedule => tr(fr: 'Ajouter un horaire', en: 'Add schedule');
+  String get addSchedule =>
+      tr(fr: 'Ajouter un horaire', en: 'Add schedule');
   String get modifySchedule =>
       tr(fr: 'Modifier l\'horaire', en: 'Edit schedule');
-  String get scheduleTimes => tr(fr: 'Horaires de prise', en: 'Intake times');
+  String get scheduleTimes =>
+      tr(fr: 'Horaires de prise', en: 'Intake times');
   String get actions => tr(fr: 'Actions', en: 'Actions');
   String get frequency => tr(fr: 'Fréquence', en: 'Frequency');
   String get start => tr(fr: 'Début', en: 'Start');
   String get end => tr(fr: 'Fin', en: 'End');
   String get description => tr(fr: 'Description', en: 'Description');
-  String get markAsTaken => tr(fr: 'Marquer comme pris', en: 'Mark as taken');
+  String get markAsTaken =>
+      tr(fr: 'Marquer comme pris', en: 'Mark as taken');
   String get skip => tr(fr: 'Ignorer', en: 'Skip');
-  String get approveAll => tr(fr: 'Tout approuver', en: 'Approve all');
-  String get rejectAll => tr(fr: 'Tout refuser', en: 'Reject all');
+  String get approveAll =>
+      tr(fr: 'Tout approuver', en: 'Approve all');
+  String get rejectAll =>
+      tr(fr: 'Tout refuser', en: 'Reject all');
   String get soonAvailable =>
       tr(fr: 'Bientôt disponible…', en: 'Coming soon...');
   String get chooseSpecialty =>
@@ -177,32 +402,55 @@ class AppLocalizations {
   String get specialties => tr(fr: 'Spécialités', en: 'Specialties');
   String get askDocAi =>
       tr(fr: 'Posez votre question à DocAI', en: 'Ask DocAI a question');
-  String get docAiAssistant => tr(fr: 'Assistant DocAI', en: 'DocAI Assistant');
-  String get viewAll => tr(fr: 'Voir tout', en: 'View All');
+  String get docAiAssistant =>
+      tr(fr: 'Assistant DocAI', en: 'DocAI Assistant');
+  String get writingStatus =>
+      tr(fr: 'En train d\'écrire…', en: 'Typing…');
+  String get online => tr(fr: 'En ligne', en: 'Online');
+  String get viewAll => tr(fr: 'Voir tout', en: 'View all');
   String get history => tr(fr: 'Historique', en: 'History');
   String get recentActivity =>
-      tr(fr: 'Activité récente', en: 'Recent Activity');
+      tr(fr: 'Activité récente', en: 'Recent activity');
   String get proMember => tr(fr: 'Membre Pro', en: 'Pro member');
-  String get todayIntakes => tr(fr: 'Prises du jour', en: 'Today\'s intakes');
+  String get todayIntakes =>
+      tr(fr: 'Prises du jour', en: 'Today\'s intakes');
   String todayIntakeProgress(int taken, int total) =>
       tr(fr: '$taken/$total prises effectuées', en: '$taken/$total taken');
   String get noIntakesToday => tr(
-      fr: 'Aucune prise prévue aujourd\'hui', en: 'No intakes scheduled today');
+        fr: 'Aucune prise prévue aujourd\'hui',
+        en: 'No intakes scheduled today',
+      );
   String get startChatDocAi =>
       tr(fr: 'Commencer un chat avec DocAI', en: 'Start a chat with DocAI');
   String intakeAlreadyTaken(String medicationName) =>
       tr(fr: 'Prise déjà effectuée', en: 'Already taken');
   String intakeSkipped(String medicationName) =>
       tr(fr: 'Prise ignorée', en: 'Skipped');
-  String markedAsTaken(String medicationName) => tr(
-      fr: '$medicationName marqué comme pris !',
-      en: '$medicationName marked as taken!');
+  String markedAsTaken(String medicationName) =>
+      tr(fr: '$medicationName marqué comme pris !', en: '$medicationName marked as taken!');
   String skippedMedication(String medicationName) =>
       tr(fr: '$medicationName ignoré', en: '$medicationName skipped');
+  String get emptyPillboxTitle =>
+      tr(fr: 'Votre pilulier est vide', en: 'Your pillbox is empty');
+  String get emptyPillboxSubtitle => tr(
+        fr: 'Ajoutez votre premier médicament pour commencer votre suivi.',
+        en: 'Add your first medication to start tracking.',
+      );
+  String get noMedicationsActive =>
+      tr(fr: 'Aucun médicament actif', en: 'No active medication');
+  String get noMedicationsInactive =>
+      tr(fr: 'Aucun médicament inactif', en: 'No inactive medication');
+  String get medicationName =>
+      tr(fr: 'Nom du médicament', en: 'Medication name');
+  String get confirmUploadFailedTitle =>
+      tr(fr: 'Échec de la confirmation', en: 'Confirmation failed');
+  String get editProfile =>
+      tr(fr: 'Modifier le profil', en: 'Edit profile');
+  String get profilePhotoChange =>
+      tr(fr: 'Fonction de changement de photo', en: 'Profile photo change feature');
 }
 
-class _AppLocalizationsDelegate
-    extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -423,9 +423,9 @@ class AppLocalizations {
   String get startChatDocAi =>
       tr(fr: 'Commencer un chat avec DocAI', en: 'Start a chat with DocAI');
   String intakeAlreadyTaken(String medicationName) =>
-      tr(fr: 'Prise déjà effectuée', en: 'Already taken');
+      tr(fr: '$medicationName : prise déjà effectuée', en: '$medicationName: already taken');
   String intakeSkipped(String medicationName) =>
-      tr(fr: 'Prise ignorée', en: 'Skipped');
+      tr(fr: '$medicationName : prise ignorée', en: '$medicationName: skipped');
   String markedAsTaken(String medicationName) =>
       tr(fr: '$medicationName marqué comme pris !', en: '$medicationName marked as taken!');
   String skippedMedication(String medicationName) =>
@@ -516,9 +516,9 @@ class AppLocalizations {
       tr(fr: '10:30 - 11:30', en: '10:30 - 11:30');
   String get lungCheckup =>
       tr(fr: 'Pour un contrôle pulmonaire', en: 'For a lung checkup');
-  String aiDoctorGreeting(String name, String specialty) => tr(
-        fr: 'Bonjour Georges ! Je suis $name, spécialiste en $specialty. Comment puis-je vous aider aujourd\'hui ?',
-        en: 'Hello Georges! I am $name, a specialist in $specialty. How can I help you today?',
+  String aiDoctorGreeting(String patientName, String name, String specialty) => tr(
+        fr: 'Bonjour $patientName ! Je suis $name, spécialiste en $specialty. Comment puis-je vous aider aujourd\'hui ?',
+        en: 'Hello $patientName! I am $name, a specialist in $specialty. How can I help you today?',
       );
   String get confirmationRequired =>
       tr(fr: 'Confirmation requise', en: 'Confirmation required');

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -15,8 +15,10 @@ class AppLocalizations {
       _AppLocalizationsDelegate();
 
   static AppLocalizations of(BuildContext context) {
-    final localizations = Localizations.of<AppLocalizations>(context, AppLocalizations);
-    assert(localizations != null, 'AppLocalizations is not available in the widget tree.');
+    final localizations =
+        Localizations.of<AppLocalizations>(context, AppLocalizations);
+    assert(localizations != null,
+        'AppLocalizations is not available in the widget tree.');
     return localizations ?? const AppLocalizations(Locale('fr'));
   }
 
@@ -25,137 +27,182 @@ class AppLocalizations {
   String tr({required String fr, required String en}) => isFrench ? fr : en;
 
   String helloUser(String name) => tr(fr: 'Bonjour, $name', en: 'Hello, $name');
+  String get hello => tr(fr: 'Bonjour', en: 'Hello');
 
   String genericError(String message) => tr(
-        fr: 'Erreur: $message',
+        fr: 'Erreur : $message',
         en: 'Error: $message',
       );
 
   String uploadFailed(String message) => tr(
-        fr: 'Echec du televersement: $message',
+        fr: 'Échec du téléversement : $message',
         en: 'Upload failed: $message',
       );
 
   String filesUploaded(int count) => tr(
-        fr: '$count fichier(s) televerse(s)',
+        fr: '$count fichier(s) téléversé(s)',
         en: '$count file(s) uploaded',
       );
 
   String fileTooLarge(String fileName) => tr(
-        fr: '$fileName depasse la limite de 25 Mo',
+        fr: '$fileName dépasse la limite de 25 Mo',
         en: '$fileName exceeds 25 MB limit',
       );
 
   String failedToDownload(String message) => tr(
-        fr: 'Echec du telechargement: $message',
+        fr: 'Échec du téléchargement : $message',
         en: 'Failed to download: $message',
       );
 
   String deleteDocumentConfirm(String fileName) => tr(
-        fr: 'Supprimer "$fileName" ? Cette action est irreversible.',
+        fr: 'Supprimer "$fileName" ? Cette action est irréversible.',
         en: 'Delete "$fileName"? This action cannot be undone.',
       );
 
   String failedToDelete(String message) => tr(
-        fr: 'Echec de la suppression: $message',
+        fr: 'Échec de la suppression : $message',
         en: 'Failed to delete: $message',
       );
 
   String pageNotFound(String uri) => tr(
-        fr: 'Page introuvable: $uri',
+        fr: 'Page introuvable : $uri',
         en: 'Page not found: $uri',
       );
 
   String invalidNumericValue() => tr(
-        fr: 'Valeur numerique invalide.',
+        fr: 'Valeur numérique invalide.',
         en: 'Invalid numeric value.',
       );
 
   String dataSaved() => tr(
-        fr: 'Donnee enregistree.',
+        fr: 'Donnée enregistrée.',
         en: 'Data saved.',
       );
 
-  String get retry => tr(fr: 'Reessayer', en: 'Retry');
+  String get retry => tr(fr: 'Réessayer', en: 'Retry');
   String get cancel => tr(fr: 'Annuler', en: 'Cancel');
   String get save => tr(fr: 'Enregistrer', en: 'Save');
   String get delete => tr(fr: 'Supprimer', en: 'Delete');
   String get edit => tr(fr: 'Modifier', en: 'Edit');
   String get add => tr(fr: 'Ajouter', en: 'Add');
   String get back => tr(fr: 'Retour', en: 'Back');
-  String get loading => tr(fr: 'Chargement...', en: 'Loading...');
+  String get loading => tr(fr: 'Chargement…', en: 'Loading...');
   String get email => tr(fr: 'Email', en: 'Email');
   String get password => tr(fr: 'Mot de passe', en: 'Password');
   String get documents => tr(fr: 'Documents', en: 'Documents');
-  String get settings => tr(fr: 'Parametres', en: 'Settings');
+  String get settings => tr(fr: 'Paramètres', en: 'Settings');
   String get language => tr(fr: 'Langue', en: 'Language');
   String get english => tr(fr: 'Anglais', en: 'English');
-  String get logout => tr(fr: 'Deconnexion', en: 'Logout');
+  String get logout => tr(fr: 'Déconnexion', en: 'Logout');
   String get cancelAction => tr(fr: 'Annuler', en: 'Cancel');
-  String get doctor => tr(fr: 'Medecin', en: 'Doctor');
+  String get doctor => tr(fr: 'Médecin', en: 'Doctor');
   String get patient => tr(fr: 'Patient', en: 'Patient');
   String get search => tr(fr: 'Recherche', en: 'Search');
   String get messages => tr(fr: 'Messages', en: 'Messages');
   String get calendar => tr(fr: 'Calendrier', en: 'Calendar');
   String get schedule => tr(fr: 'Programme', en: 'Schedule');
   String get lists => tr(fr: 'Liste', en: 'Lists');
-  String get upcoming => tr(fr: 'A venir', en: 'Upcoming');
-  String get past => tr(fr: 'Passes', en: 'Past');
-  String get cancelled => tr(fr: 'Annules', en: 'Cancelled');
+  String get upcoming => tr(fr: 'À venir', en: 'Upcoming');
+  String get past => tr(fr: 'Passés', en: 'Past');
+  String get cancelled => tr(fr: 'Annulés', en: 'Cancelled');
   String get total => tr(fr: 'Total', en: 'Total');
   String get active => tr(fr: 'Actifs', en: 'Active');
   String get inactive => tr(fr: 'Inactifs', en: 'Inactive');
   String get all => tr(fr: 'Tous', en: 'All');
   String get myDocuments => tr(fr: 'Mes documents', en: 'My Documents');
   String get yourDocuments => tr(fr: 'Vos documents', en: 'Your Documents');
-  String get uploading => tr(fr: 'Televersement...', en: 'Uploading...');
-  String get uploadDocuments => tr(fr: 'Televerser des documents', en: 'Upload Documents');
-  String get noDocumentsYet => tr(fr: 'Aucun document pour le moment', en: 'No documents yet');
+  String get uploading => tr(fr: 'Téléversement…', en: 'Uploading...');
+  String get uploadingTitle => tr(fr: 'Téléversement', en: 'Uploading');
+  String get uploadDocuments =>
+      tr(fr: 'Téléverser des documents', en: 'Upload Documents');
+  String get noDocumentsYet =>
+      tr(fr: 'Aucun document pour le moment', en: 'No documents yet');
   String get uploadFirstDocument => tr(
-        fr: 'Televersez votre premier document pour commencer',
+        fr: 'Téléversez votre premier document pour commencer',
         en: 'Upload your first document to get started',
       );
-  String get deleteDocumentTitle => tr(fr: 'Supprimer le document', en: 'Delete Document');
-  String get documentDeleted => tr(fr: 'Document supprime', en: 'Document deleted');
+  String get deleteDocumentTitle =>
+      tr(fr: 'Supprimer le document', en: 'Delete Document');
+  String get documentDeleted =>
+      tr(fr: 'Document supprimé', en: 'Document deleted');
+  String confirmUploadFailed(String message) => tr(
+        fr: 'Échec de la confirmation du téléversement : $message',
+        en: 'Upload confirmation failed: $message',
+      );
   String get noAvailableSlots => tr(
-        fr: 'Aucun creneau disponible pour cette date.',
+        fr: 'Aucun créneau disponible pour cette date.',
         en: 'No available slots for this date.',
       );
-  String get bookAppointment => tr(fr: 'Prendre rendez-vous', en: 'Book an appointment');
-  String get confirmAppointment => tr(fr: 'Confirmer le rendez-vous', en: 'Confirm appointment');
-  String get addMedication => tr(fr: 'Ajouter un medicament', en: 'Add medication');
-  String get addToPillbox => tr(fr: 'Ajouter au pilulier', en: 'Add to pillbox');
-  String get medicationPlan => tr(fr: 'Plan de medicaments', en: 'Medication Plan');
-  String get medicationNotFound => tr(fr: 'Medicament introuvable', en: 'Medication not found');
+  String get bookAppointment =>
+      tr(fr: 'Prendre rendez-vous', en: 'Book an appointment');
+  String get confirmAppointment =>
+      tr(fr: 'Confirmer le rendez-vous', en: 'Confirm appointment');
+  String get addMedication =>
+      tr(fr: 'Ajouter un médicament', en: 'Add medication');
+  String get addMedicationsWithSchedules => tr(
+      fr: 'Ajoutez des médicaments avec des horaires',
+      en: 'Add medications with schedules');
+  String get addMedicationShort =>
+      tr(fr: 'Ajouter un médicament', en: 'Add medication');
+  String get addToPillbox =>
+      tr(fr: 'Ajouter au pilulier', en: 'Add to pillbox');
+  String get medicationPlan =>
+      tr(fr: 'Plan de médicaments', en: 'Medication Plan');
+  String get medicationNotFound =>
+      tr(fr: 'Médicament introuvable', en: 'Medication not found');
   String get instructions => tr(fr: 'Instructions', en: 'Instructions');
-  String get quantity => tr(fr: 'Quantite', en: 'Quantity');
-  String get unit => tr(fr: 'Unite', en: 'Unit');
-  String get notesOptional => tr(fr: 'Notes (optionnel)', en: 'Notes (optional)');
-  String get momentOfDay => tr(fr: 'Moment de la journee', en: 'Time of day');
+  String get quantity => tr(fr: 'Quantité', en: 'Quantity');
+  String get unit => tr(fr: 'Unité', en: 'Unit');
+  String get notesOptional =>
+      tr(fr: 'Notes (optionnel)', en: 'Notes (optional)');
+  String get momentOfDay => tr(fr: 'Moment de la journée', en: 'Time of day');
   String get timeOfIntake => tr(fr: 'Heure de prise', en: 'Intake time');
   String get addSchedule => tr(fr: 'Ajouter un horaire', en: 'Add schedule');
-  String get modifySchedule => tr(fr: 'Modifier l\'horaire', en: 'Edit schedule');
+  String get modifySchedule =>
+      tr(fr: 'Modifier l\'horaire', en: 'Edit schedule');
   String get scheduleTimes => tr(fr: 'Horaires de prise', en: 'Intake times');
   String get actions => tr(fr: 'Actions', en: 'Actions');
-  String get frequency => tr(fr: 'Frequence', en: 'Frequency');
-  String get start => tr(fr: 'Debut', en: 'Start');
+  String get frequency => tr(fr: 'Fréquence', en: 'Frequency');
+  String get start => tr(fr: 'Début', en: 'Start');
   String get end => tr(fr: 'Fin', en: 'End');
   String get description => tr(fr: 'Description', en: 'Description');
   String get markAsTaken => tr(fr: 'Marquer comme pris', en: 'Mark as taken');
   String get skip => tr(fr: 'Ignorer', en: 'Skip');
   String get approveAll => tr(fr: 'Tout approuver', en: 'Approve all');
   String get rejectAll => tr(fr: 'Tout refuser', en: 'Reject all');
-  String get soonAvailable => tr(fr: 'Bientot disponible...', en: 'Coming soon...');
-  String get chooseSpecialty => tr(fr: 'Choisir une specialite', en: 'Choose a specialty');
-  String get specialties => tr(fr: 'Specialites', en: 'Specialties');
-  String get askDocAi => tr(fr: 'Posez votre question a DocAI', en: 'Ask DocAI a question');
+  String get soonAvailable =>
+      tr(fr: 'Bientôt disponible…', en: 'Coming soon...');
+  String get chooseSpecialty =>
+      tr(fr: 'Choisir une spécialité', en: 'Choose a specialty');
+  String get specialties => tr(fr: 'Spécialités', en: 'Specialties');
+  String get askDocAi =>
+      tr(fr: 'Posez votre question à DocAI', en: 'Ask DocAI a question');
   String get docAiAssistant => tr(fr: 'Assistant DocAI', en: 'DocAI Assistant');
   String get viewAll => tr(fr: 'Voir tout', en: 'View All');
-  String get recentActivity => tr(fr: 'Activite recente', en: 'Recent Activity');
-  String get startChatDocAi => tr(fr: 'Commencer un chat avec DocAI', en: 'Start a chat with DocAI');
+  String get history => tr(fr: 'Historique', en: 'History');
+  String get recentActivity =>
+      tr(fr: 'Activité récente', en: 'Recent Activity');
+  String get proMember => tr(fr: 'Membre Pro', en: 'Pro member');
+  String get todayIntakes => tr(fr: 'Prises du jour', en: 'Today\'s intakes');
+  String todayIntakeProgress(int taken, int total) =>
+      tr(fr: '$taken/$total prises effectuées', en: '$taken/$total taken');
+  String get noIntakesToday => tr(
+      fr: 'Aucune prise prévue aujourd\'hui', en: 'No intakes scheduled today');
+  String get startChatDocAi =>
+      tr(fr: 'Commencer un chat avec DocAI', en: 'Start a chat with DocAI');
+  String intakeAlreadyTaken(String medicationName) =>
+      tr(fr: 'Prise déjà effectuée', en: 'Already taken');
+  String intakeSkipped(String medicationName) =>
+      tr(fr: 'Prise ignorée', en: 'Skipped');
+  String markedAsTaken(String medicationName) => tr(
+      fr: '$medicationName marqué comme pris !',
+      en: '$medicationName marked as taken!');
+  String skippedMedication(String medicationName) =>
+      tr(fr: '$medicationName ignoré', en: '$medicationName skipped');
 }
 
-class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -168,7 +215,8 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
   }
 
   @override
-  bool shouldReload(covariant LocalizationsDelegate<AppLocalizations> old) => false;
+  bool shouldReload(covariant LocalizationsDelegate<AppLocalizations> old) =>
+      false;
 }
 
 extension AppLocalizationsContext on BuildContext {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -448,6 +448,122 @@ class AppLocalizations {
       tr(fr: 'Modifier le profil', en: 'Edit profile');
   String get profilePhotoChange =>
       tr(fr: 'Fonction de changement de photo', en: 'Profile photo change feature');
+  String get welcome => tr(fr: 'Bienvenue', en: 'Welcome');
+  String get noAccountYet =>
+      tr(fr: 'Pas encore de compte ?', en: 'No account yet?');
+  String get signUp => tr(fr: 'S\'inscrire', en: 'Sign up');
+  String get signIn => tr(fr: 'Se connecter', en: 'Sign in');
+  String get createAccount =>
+      tr(fr: 'Créer un compte', en: 'Create an account');
+  String get createMyAccount =>
+      tr(fr: 'Créer mon compte', en: 'Create my account');
+  String get next => tr(fr: 'Suivant', en: 'Next');
+  String get resetPasswordTitle =>
+      tr(fr: 'Réinitialisation', en: 'Reset password');
+  String get resetPasswordHelp => tr(
+        fr: 'Pas de souci ! Entrez votre adresse email et nous vous enverrons un lien pour réinitialiser votre mot de passe',
+        en: 'No worries! Enter your email address and we will send you a link to reset your password',
+      );
+  String resetEmailSentTo(String email) => tr(
+        fr: 'Nous avons envoyé un lien de réinitialisation à',
+        en: 'We have sent a reset link to',
+      ) + ' $email';
+  String get resetCheckInbox => tr(
+        fr: 'Vérifiez votre boîte de réception et cliquez sur le lien pour réinitialiser votre mot de passe',
+        en: 'Check your inbox and click the link to reset your password',
+      );
+  String get resendEmail => tr(fr: 'Renvoyer l\'email', en: 'Resend email');
+  String get sendLink =>
+      tr(fr: 'Envoyer le lien', en: 'Send the link');
+  String get chooseSpecialist =>
+      tr(fr: 'Choisir un spécialiste', en: 'Choose a specialist');
+  String get close => tr(fr: 'Fermer', en: 'Close');
+  String get clearHistory =>
+      tr(fr: 'Effacer l\'historique', en: 'Clear history');
+  String get connecting => tr(fr: 'Connexion...', en: 'Connecting...');
+  String get generalPractitioner =>
+      tr(fr: 'Médecin généraliste', en: 'General practitioner');
+  String get generalMedicine =>
+      tr(fr: 'Médecine générale', en: 'General medicine');
+  String get dermatologist =>
+      tr(fr: 'Dermatologue', en: 'Dermatologist');
+  String get dermatology =>
+      tr(fr: 'Dermatologie', en: 'Dermatology');
+  String get nutritionist =>
+      tr(fr: 'Nutritionniste', en: 'Nutritionist');
+  String get nutrition => tr(fr: 'Nutrition', en: 'Nutrition');
+  String get psychologist =>
+      tr(fr: 'Psychologue', en: 'Psychologist');
+  String get mentalHealth =>
+      tr(fr: 'Santé mentale', en: 'Mental health');
+  String get lungSpecialist =>
+      tr(fr: 'Spécialiste des poumons', en: 'Lung specialist');
+  String get appointmentConfirmedTomorrowAt1030 => tr(
+        fr: 'Votre rendez-vous est confirmé pour demain à 10h30',
+        en: 'Your appointment is confirmed for tomorrow at 10:30 AM',
+      );
+  String get takeMedicationThisMorning => tr(
+        fr: 'N\'oubliez pas de prendre votre médicament ce matin',
+        en: 'Do not forget to take your medication this morning',
+      );
+  String get examResultsAvailable => tr(
+        fr: 'Vos résultats d\'examen sont disponibles',
+        en: 'Your test results are available',
+      );
+  String get searchConversations =>
+      tr(fr: 'Rechercher des conversations...', en: 'Search conversations...');
+  String get doctorCardTimeSlot =>
+      tr(fr: '10:30 - 11:30', en: '10:30 - 11:30');
+  String get lungCheckup =>
+      tr(fr: 'Pour un contrôle pulmonaire', en: 'For a lung checkup');
+  String aiDoctorGreeting(String name, String specialty) => tr(
+        fr: 'Bonjour Georges ! Je suis $name, spécialiste en $specialty. Comment puis-je vous aider aujourd\'hui ?',
+        en: 'Hello Georges! I am $name, a specialist in $specialty. How can I help you today?',
+      );
+  String get confirmationRequired =>
+      tr(fr: 'Confirmation requise', en: 'Confirmation required');
+  String get passwordsDifferent =>
+      tr(fr: 'Mots de passe différents', en: 'Passwords do not match');
+  String get pleaseEnterEmail =>
+      tr(fr: 'Veuillez saisir votre email', en: 'Please enter your email');
+  String get pleaseEnterValidEmail => tr(
+        fr: 'Veuillez saisir un email valide',
+        en: 'Please enter a valid email',
+      );
+  String fieldRequired(String fieldName) =>
+      tr(fr: '$fieldName est requis', en: '$fieldName is required');
+  String fieldMustContainAtLeast(String fieldName, int min) => tr(
+        fr: '$fieldName doit contenir au moins $min caractères',
+        en: '$fieldName must contain at least $min characters',
+      );
+  String fieldCannotExceed(String fieldName, int max) => tr(
+        fr: '$fieldName ne peut pas dépasser $max caractères',
+        en: '$fieldName cannot exceed $max characters',
+      );
+  String get pleaseEnterPassword => tr(
+        fr: 'Veuillez saisir un mot de passe',
+        en: 'Please enter a password',
+      );
+  String get passwordMustContainLowercase => tr(
+        fr: 'Le mot de passe doit contenir au moins une minuscule',
+        en: 'Password must contain at least one lowercase letter',
+      );
+  String get passwordMustContainUppercase => tr(
+        fr: 'Le mot de passe doit contenir au moins une majuscule',
+        en: 'Password must contain at least one uppercase letter',
+      );
+  String get passwordMustContainDigit => tr(
+        fr: 'Le mot de passe doit contenir au moins un chiffre',
+        en: 'Password must contain at least one digit',
+      );
+  String get passwordMustContainSpecialCharacter => tr(
+        fr: 'Le mot de passe doit contenir au moins un caractère spécial',
+        en: 'Password must contain at least one special character',
+      );
+  String get passwordMustBeBetween8And100Characters => tr(
+        fr: 'Le mot de passe doit contenir entre 8 et 100 caractères',
+        en: 'Password must be between 8 and 100 characters long',
+      );
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -75,16 +75,6 @@ class AppLocalizations {
         en: 'Page not found: $uri',
       );
 
-  String invalidNumericValue() => tr(
-        fr: 'Valeur numérique invalide.',
-        en: 'Invalid numeric value.',
-      );
-
-  String dataSaved() => tr(
-        fr: 'Donnée enregistrée.',
-        en: 'Data saved.',
-      );
-
   String get retry => tr(fr: 'Réessayer', en: 'Retry');
   String get cancel => tr(fr: 'Annuler', en: 'Cancel');
   String get save => tr(fr: 'Enregistrer', en: 'Save');
@@ -311,22 +301,14 @@ class AppLocalizations {
         fr: 'Échec de la confirmation du téléversement : $message',
         en: 'Upload confirmation failed: $message',
       );
-  String get noAvailableSlots => tr(
-        fr: 'Aucun créneau disponible pour cette date.',
-        en: 'No available slots for this date.',
-      );
   String get bookAppointment =>
       tr(fr: 'Prendre rendez-vous', en: 'Book an appointment');
-  String get confirmAppointment =>
-      tr(fr: 'Confirmer le rendez-vous', en: 'Confirm appointment');
   String get addMedication =>
       tr(fr: 'Ajouter un médicament', en: 'Add medication');
   String get addMedicationsWithSchedules => tr(
         fr: 'Ajoutez des médicaments avec des horaires',
         en: 'Add medications with schedules',
       );
-  String get addMedicationShort =>
-      tr(fr: 'Ajouter un médicament', en: 'Add medication');
   String get addToPillbox =>
       tr(fr: 'Ajouter au pilulier', en: 'Add to pillbox');
   String get medicationPlan =>
@@ -446,8 +428,6 @@ class AppLocalizations {
       tr(fr: 'Échec de la confirmation', en: 'Confirmation failed');
   String get editProfile =>
       tr(fr: 'Modifier le profil', en: 'Edit profile');
-  String get profilePhotoChange =>
-      tr(fr: 'Fonction de changement de photo', en: 'Profile photo change feature');
   String get welcome => tr(fr: 'Bienvenue', en: 'Welcome');
   String get noAccountYet =>
       tr(fr: 'Pas encore de compte ?', en: 'No account yet?');
@@ -512,8 +492,6 @@ class AppLocalizations {
       );
   String get searchConversations =>
       tr(fr: 'Rechercher des conversations...', en: 'Search conversations...');
-  String get doctorCardTimeSlot =>
-      tr(fr: '10:30 - 11:30', en: '10:30 - 11:30');
   String get lungCheckup =>
       tr(fr: 'Pour un contrôle pulmonaire', en: 'For a lung checkup');
   String aiDoctorGreeting(String patientName, String name, String specialty) => tr(

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -524,12 +524,6 @@ class AppLocalizations {
       tr(fr: 'Confirmation requise', en: 'Confirmation required');
   String get passwordsDifferent =>
       tr(fr: 'Mots de passe différents', en: 'Passwords do not match');
-  String get pleaseEnterEmail =>
-      tr(fr: 'Veuillez saisir votre email', en: 'Please enter your email');
-  String get pleaseEnterValidEmail => tr(
-        fr: 'Veuillez saisir un email valide',
-        en: 'Please enter a valid email',
-      );
   String fieldRequired(String fieldName) =>
       tr(fr: '$fieldName est requis', en: '$fieldName is required');
   String fieldMustContainAtLeast(String fieldName, int min) => tr(

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -21,10 +21,7 @@ class AppLocalizations {
       localizations != null,
       'AppLocalizations is not available in the widget tree.',
     );
-    if (localizations == null) {
-      throw StateError('AppLocalizations is not available in the widget tree.');
-    }
-    return localizations;
+    return localizations!;
   }
 
   bool get isFrench => locale.languageCode == 'fr';
@@ -95,7 +92,7 @@ class AppLocalizations {
   String get approved => tr(fr: 'Approuvé', en: 'Approved');
   String get rejected => tr(fr: 'Refusé', en: 'Rejected');
   String get back => tr(fr: 'Retour', en: 'Back');
-  String get loading => tr(fr: 'Chargement...', en: 'Loading...');
+  String get loading => tr(fr: 'Chargement…', en: 'Loading…');
   String get email => tr(fr: 'Email', en: 'Email');
   String get password => tr(fr: 'Mot de passe', en: 'Password');
   String get connectToContinue =>
@@ -197,9 +194,8 @@ class AppLocalizations {
   String hoursAgo(int hours) =>
       tr(fr: 'Il y a $hours h', en: '$hours h ago');
   String get yesterday => tr(fr: 'Hier', en: 'Yesterday');
-  String formattedDate(String date) => tr(fr: date, en: date);
   String get searchDoctor =>
-      tr(fr: 'Rechercher un médecin...', en: 'Search for a doctor...');
+      tr(fr: 'Rechercher un médecin…', en: 'Search for a doctor…');
   String get consultDoctorsToBook =>
       tr(fr: 'Consultez la liste des médecins pour prendre rendez-vous.', en: 'Browse the doctor list to book an appointment.');
   String get noDoctorsAvailable =>
@@ -262,7 +258,7 @@ class AppLocalizations {
   String get addMeasure => tr(fr: 'Ajouter une donnée', en: 'Add measurement');
   String get today => tr(fr: "Aujourd'hui", en: 'Today');
   String get confirmed => tr(fr: 'Confirmé', en: 'Confirmed');
-  String get appName => tr(fr: 'CoreVia Mobile', en: 'CoreVia Mobile');
+  static const String appName = 'CoreVia Mobile';
   String get exampleValue => tr(fr: 'Ex: 120', en: 'Ex: 120');
   String get editing => tr(fr: 'Modifier', en: 'Edit');
   String get appointmentDate => tr(fr: 'Date', en: 'Date');
@@ -290,7 +286,7 @@ class AppLocalizations {
   String get messages => tr(fr: 'Messages', en: 'Messages');
   String get calendar => tr(fr: 'Calendrier', en: 'Calendar');
   String get schedule => tr(fr: 'Programme', en: 'Schedule');
-  String get lists => tr(fr: 'Liste', en: 'Lists');
+  String get lists => tr(fr: 'Listes', en: 'Lists');
   String get upcoming => tr(fr: 'À venir', en: 'Upcoming');
   String get past => tr(fr: 'Passés', en: 'Past');
   String get cancelled => tr(fr: 'Annulés', en: 'Cancelled');
@@ -301,7 +297,7 @@ class AppLocalizations {
   String get loadMore => tr(fr: 'Charger plus', en: 'Load more');
   String get myDocuments => tr(fr: 'Mes documents', en: 'My Documents');
   String get yourDocuments => tr(fr: 'Vos documents', en: 'Your Documents');
-  String get uploading => tr(fr: 'Téléversement...', en: 'Uploading...');
+  String get uploading => tr(fr: 'Téléversement…', en: 'Uploading…');
   String get uploadingTitle => tr(fr: 'Téléversement', en: 'Uploading');
   String get uploadDocuments =>
       tr(fr: 'Téléverser des documents', en: 'Upload documents');
@@ -396,7 +392,7 @@ class AppLocalizations {
   String get rejectAll =>
       tr(fr: 'Tout refuser', en: 'Reject all');
   String get soonAvailable =>
-      tr(fr: 'Bientôt disponible…', en: 'Coming soon...');
+      tr(fr: 'Bientôt disponible…', en: 'Coming soon…');
   String get chooseSpecialty =>
       tr(fr: 'Choisir une spécialité', en: 'Choose a specialty');
   String get specialties => tr(fr: 'Spécialités', en: 'Specialties');
@@ -480,7 +476,7 @@ class AppLocalizations {
   String get close => tr(fr: 'Fermer', en: 'Close');
   String get clearHistory =>
       tr(fr: 'Effacer l\'historique', en: 'Clear history');
-  String get connecting => tr(fr: 'Connexion...', en: 'Connecting...');
+  String get connecting => tr(fr: 'Connexion…', en: 'Connecting…');
   String get generalPractitioner =>
       tr(fr: 'Médecin généraliste', en: 'General practitioner');
   String get generalMedicine =>
@@ -511,7 +507,7 @@ class AppLocalizations {
         en: 'Your test results are available',
       );
   String get searchConversations =>
-      tr(fr: 'Rechercher des conversations...', en: 'Search conversations...');
+      tr(fr: 'Rechercher des conversations…', en: 'Search conversations…');
   String get lungCheckup =>
       tr(fr: 'Pour un contrôle pulmonaire', en: 'For a lung checkup');
   String aiDoctorGreeting(String patientName, String name, String specialty) => tr(

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -465,9 +465,9 @@ class AppLocalizations {
         en: 'No worries! Enter your email address and we will send you a link to reset your password',
       );
   String resetEmailSentTo(String email) => tr(
-        fr: 'Nous avons envoyé un lien de réinitialisation à',
-        en: 'We have sent a reset link to',
-      ) + ' $email';
+        fr: 'Nous avons envoyé un lien de réinitialisation à $email',
+        en: 'We have sent a reset link to $email',
+      );
   String get resetCheckInbox => tr(
         fr: 'Vérifiez votre boîte de réception et cliquez sur le lien pour réinitialiser votre mot de passe',
         en: 'Check your inbox and click the link to reset your password',

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -39,10 +39,18 @@ class AppLocalizations {
         fr: 'Erreur : $message',
         en: 'Error: $message',
       );
+  String get genericErrorNoDetails =>
+      tr(fr: 'Une erreur est survenue.', en: 'Something went wrong.');
 
   String uploadFailed(String message) => tr(
         fr: 'Échec du téléversement : $message',
         en: 'Upload failed: $message',
+      );
+  String get uploadFailedNetwork =>
+      tr(fr: 'Échec du téléversement réseau', en: 'Network upload failed');
+  String get uploadFailedFileTooLarge => tr(
+        fr: 'Le fichier dépasse la taille autorisée',
+        en: 'The file is too large',
       );
 
   String filesUploaded(int count) => tr(
@@ -92,6 +100,10 @@ class AppLocalizations {
   String get delete => tr(fr: 'Supprimer', en: 'Delete');
   String get edit => tr(fr: 'Modifier', en: 'Edit');
   String get add => tr(fr: 'Ajouter', en: 'Add');
+  String get approve => tr(fr: 'Approuver', en: 'Approve');
+  String get reject => tr(fr: 'Refuser', en: 'Reject');
+  String get approved => tr(fr: 'Approuvé', en: 'Approved');
+  String get rejected => tr(fr: 'Refusé', en: 'Rejected');
   String get back => tr(fr: 'Retour', en: 'Back');
   String get loading => tr(fr: 'Chargement...', en: 'Loading...');
   String get email => tr(fr: 'Email', en: 'Email');
@@ -184,6 +196,12 @@ class AppLocalizations {
       tr(fr: 'Minimum 3 caractères', en: 'Minimum 3 characters');
   String get noResultsFound =>
       tr(fr: 'Aucun résultat. Essayez un nom de molécule (ex: paracétamol).', en: 'No results. Try a molecule name (e.g. paracetamol).');
+  String get none => tr(fr: 'Aucune', en: 'None');
+  String get custom => tr(fr: 'Autre', en: 'Custom');
+  String get morning => tr(fr: 'Matin', en: 'Morning');
+  String get noon => tr(fr: 'Midi', en: 'Noon');
+  String get evening => tr(fr: 'Soir', en: 'Evening');
+  String get bedtime => tr(fr: 'Coucher', en: 'Bedtime');
   String minutesAgo(int minutes) =>
       tr(fr: 'Il y a $minutes min', en: '$minutes min ago');
   String hoursAgo(int hours) =>
@@ -420,6 +438,8 @@ class AppLocalizations {
         fr: 'Aucune prise prévue aujourd\'hui',
         en: 'No intakes scheduled today',
       );
+  String get noMedicationsScheduled =>
+      tr(fr: 'Pas de médicaments programmés', en: 'No medications scheduled');
   String get startChatDocAi =>
       tr(fr: 'Commencer un chat avec DocAI', en: 'Start a chat with DocAI');
   String intakeAlreadyTaken(String medicationName) =>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -181,7 +181,7 @@ class MyApp extends StatelessWidget {
 
     return MaterialApp.router(
       debugShowCheckedModeBanner: false,
-      onGenerateTitle: (context) => AppLocalizations.of(context).appName,
+      onGenerateTitle: (context) => AppLocalizations.appName,
       supportedLocales: AppLocalizations.supportedLocales,
       localizationsDelegates: const [
         AppLocalizations.delegate,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:timezone/data/latest_all.dart' as tz_data;
@@ -21,6 +22,7 @@ import 'features/booking/presentation/providers/booking_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:go_router/go_router.dart';
+import 'l10n/app_localizations.dart';
 import 'core/providers/notifiers.dart';
 import 'networking/api_service.dart';
 import 'networking/routes/user_routes.dart';
@@ -170,6 +172,14 @@ class MyApp extends StatelessWidget {
     return MaterialApp.router(
       debugShowCheckedModeBanner: false,
       title: 'CoreVia Mobile',
+      locale: const Locale('fr'),
+      supportedLocales: AppLocalizations.supportedLocales,
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
       theme: AppTheme.lightTheme,
       routerConfig: router,
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,6 +59,7 @@ void main() async {
 
   final onboardingNotifier = OnboardingNotifier(onboardingNeeded);
   final authNotifier = AuthNotifier(false);
+  final localeNotifier = LocaleNotifier(await LocaleNotifier.load());
 
   // Restore local session first (persistent login)
   const secureStorage = FlutterSecureStorage();
@@ -159,6 +160,9 @@ void main() async {
         ChangeNotifierProvider<AuthNotifier>.value(
           value: authNotifier,
         ),
+        ChangeNotifierProvider<LocaleNotifier>.value(
+          value: localeNotifier,
+        ),
       ],
       child: MyApp(router: router),
     ),
@@ -172,9 +176,14 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final localeNotifier = context.watch<LocaleNotifier>();
+    final locale = localeNotifier.value;
+
     return MaterialApp.router(
       debugShowCheckedModeBanner: false,
-      title: AppLocalizations(Locale('fr')).appName,
+      title: AppLocalizations(
+        locale ?? WidgetsBinding.instance.platformDispatcher.locale,
+      ).appName,
       supportedLocales: AppLocalizations.supportedLocales,
       localizationsDelegates: const [
         AppLocalizations.delegate,
@@ -182,15 +191,7 @@ class MyApp extends StatelessWidget {
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
       ],
-      localeResolutionCallback: (deviceLocale, supportedLocales) {
-        if (deviceLocale == null) return const Locale('fr');
-        for (final supportedLocale in supportedLocales) {
-          if (supportedLocale.languageCode == deviceLocale.languageCode) {
-            return supportedLocale;
-          }
-        }
-        return const Locale('fr');
-      },
+      locale: locale,
       theme: AppTheme.lightTheme,
       routerConfig: router,
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -174,7 +174,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       debugShowCheckedModeBanner: false,
-      title: 'CoreVia Mobile',
+      title: AppLocalizations(Locale('fr')).appName,
       supportedLocales: AppLocalizations.supportedLocales,
       localizationsDelegates: const [
         AppLocalizations.delegate,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:timezone/data/latest_all.dart' as tz_data;
@@ -31,6 +32,8 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   try {
     await dotenv.load(fileName: ".env");
+    await initializeDateFormatting('fr_FR', null);
+    await initializeDateFormatting('en_US', null);
   } catch (e) {
     // Keep boot resilient in dev setups where `.env` isn't present yet.
     debugPrint('⚠️  Unable to load .env (continuing): $e');
@@ -172,7 +175,6 @@ class MyApp extends StatelessWidget {
     return MaterialApp.router(
       debugShowCheckedModeBanner: false,
       title: 'CoreVia Mobile',
-      locale: const Locale('fr'),
       supportedLocales: AppLocalizations.supportedLocales,
       localizationsDelegates: const [
         AppLocalizations.delegate,
@@ -180,6 +182,15 @@ class MyApp extends StatelessWidget {
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
       ],
+      localeResolutionCallback: (deviceLocale, supportedLocales) {
+        if (deviceLocale == null) return const Locale('fr');
+        for (final supportedLocale in supportedLocales) {
+          if (supportedLocale.languageCode == deviceLocale.languageCode) {
+            return supportedLocale;
+          }
+        }
+        return const Locale('fr');
+      },
       theme: AppTheme.lightTheme,
       routerConfig: router,
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -181,9 +181,7 @@ class MyApp extends StatelessWidget {
 
     return MaterialApp.router(
       debugShowCheckedModeBanner: false,
-      title: AppLocalizations(
-        locale ?? WidgetsBinding.instance.platformDispatcher.locale,
-      ).appName,
+      onGenerateTitle: (context) => AppLocalizations.of(context).appName,
       supportedLocales: AppLocalizations.supportedLocales,
       localizationsDelegates: const [
         AppLocalizations.delegate,

--- a/lib/widgets/medication_detail_modal.dart
+++ b/lib/widgets/medication_detail_modal.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
+import '../l10n/app_localizations.dart';
 import './pill_shadow.dart';
 
 class MedicationDetailModal extends StatelessWidget {
@@ -100,7 +101,7 @@ class MedicationDetailModal extends StatelessWidget {
                   _buildInfoRow(LucideIcons.calendarCheck, 'Fin', endDate),
 
                   const SizedBox(height: 24),
-                  Text('Description',
+                  Text(context.l10n.description,
                       style: TextStyle(
                           fontWeight: FontWeight.w700,
                           color: Colors.grey.shade800,
@@ -110,7 +111,7 @@ class MedicationDetailModal extends StatelessWidget {
                       style: TextStyle(color: Colors.grey.shade700)),
 
                   const SizedBox(height: 16),
-                  Text('Instructions',
+                  Text(context.l10n.instructions,
                       style: TextStyle(
                           fontWeight: FontWeight.w700,
                           color: Colors.grey.shade800,

--- a/lib/widgets/medication_detail_modal.dart
+++ b/lib/widgets/medication_detail_modal.dart
@@ -47,7 +47,7 @@ class MedicationDetailModal extends StatelessWidget {
         children: [
           // --- CONTENU DU DIALOG ---
           Container(
-            margin: const EdgeInsets.only(top: 75), // laisse la place à l'image
+            margin: const EdgeInsets.only(top: 75), // laisse la place Ã  l'image
             padding: const EdgeInsets.all(20),
             decoration: BoxDecoration(
               color: Colors.white,
@@ -93,11 +93,11 @@ class MedicationDetailModal extends StatelessWidget {
 
                   const SizedBox(height: 24),
 
-                  _buildInfoRow(LucideIcons.repeat, 'Frequency', frequency),
+                  _buildInfoRow(LucideIcons.repeat, 'Frequence', frequency),
                   const SizedBox(height: 12),
-                  _buildInfoRow(LucideIcons.calendar, 'Start', startDate),
+                  _buildInfoRow(LucideIcons.calendar, 'Debut', startDate),
                   const SizedBox(height: 8),
-                  _buildInfoRow(LucideIcons.calendarCheck, 'End', endDate),
+                  _buildInfoRow(LucideIcons.calendarCheck, 'Fin', endDate),
 
                   const SizedBox(height: 24),
                   Text('Description',
@@ -136,7 +136,7 @@ class MedicationDetailModal extends StatelessWidget {
                     child: ElevatedButton.icon(
                       icon: const Icon(LucideIcons.check, color: Colors.white),
                       label: const Text(
-                        'Mark as Taken',
+                        'Marquer comme pris',
                         style: TextStyle(
                             fontSize: 16,
                             fontWeight: FontWeight.w600,
@@ -156,7 +156,7 @@ class MedicationDetailModal extends StatelessWidget {
                         }
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
-                            content: Text('$medicationName marked as taken!'),
+                            content: Text('$medicationName marqué comme pris !'),
                             backgroundColor: Colors.green,
                           ),
                         );
@@ -175,7 +175,7 @@ class MedicationDetailModal extends StatelessWidget {
                         }
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
-                            content: Text('$medicationName skipped'),
+                            content: Text('$medicationName ignoré'),
                             backgroundColor: Colors.orange,
                           ),
                         );
@@ -187,7 +187,7 @@ class MedicationDetailModal extends StatelessWidget {
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                      child: const Text('Skip'),
+                      child: const Text('Ignorer'),
                     ),
                   ),
                 ],
@@ -195,7 +195,7 @@ class MedicationDetailModal extends StatelessWidget {
             ),
           ),
 
-          // --- IMAGE CENTRÉE SUR LA BORDURE DU HAUT ---
+          // --- IMAGE CENTRÃ‰E SUR LA BORDURE DU HAUT ---
           Positioned(
             top: 0,
             left: 0,
@@ -255,3 +255,6 @@ class MedicationDetailModal extends StatelessWidget {
 //     instructions: "Take with food",
 //   ),
 // );
+
+
+

--- a/lib/widgets/medication_detail_modal.dart
+++ b/lib/widgets/medication_detail_modal.dart
@@ -46,14 +46,13 @@ class MedicationDetailModal extends StatelessWidget {
       child: Stack(
         clipBehavior: Clip.none,
         children: [
-          // --- CONTENU DU DIALOG ---
+          // --- Contenu du dialog ---
           Container(
-            margin: const EdgeInsets.only(top: 75), // laisse la place Ã  l'image
+            margin: const EdgeInsets.only(top: 75), // laisse la place à l'image
             padding: const EdgeInsets.all(20),
             decoration: BoxDecoration(
               color: Colors.white,
               borderRadius: BorderRadius.circular(16),
-              //border: Border.all(color: Colors.pink.shade200, width: 2),
             ),
             child: SingleChildScrollView(
               child: Column(
@@ -73,59 +72,73 @@ class MedicationDetailModal extends StatelessWidget {
                             Text(
                               medicationName,
                               style: const TextStyle(
-                                  fontSize: 35, fontWeight: FontWeight.bold),
+                                fontSize: 35,
+                                fontWeight: FontWeight.bold,
+                              ),
                             ),
                             Row(
                               mainAxisAlignment: MainAxisAlignment.center,
                               children: [
-                                Text('$dosage . $time',
-                                    style: TextStyle(color: Colors.black)),
+                                Text(
+                                  '$dosage . $time',
+                                  style: const TextStyle(color: Colors.black),
+                                ),
                               ],
-                            )
+                            ),
                           ],
                         ),
                       ),
-                      // IconButton(
-                      //   icon: const Icon(Icons.close),
-                      //   onPressed: () => Navigator.pop(context),
-                      // ),
                     ],
                   ),
 
                   const SizedBox(height: 24),
-
-                  _buildInfoRow(LucideIcons.repeat, 'Frequence', frequency),
+                  _buildInfoRow(
+                      LucideIcons.repeat, context.l10n.frequency, frequency),
                   const SizedBox(height: 12),
-                  _buildInfoRow(LucideIcons.calendar, 'Debut', startDate),
+                  _buildInfoRow(
+                      LucideIcons.calendar, context.l10n.start, startDate),
                   const SizedBox(height: 8),
-                  _buildInfoRow(LucideIcons.calendarCheck, 'Fin', endDate),
+                  _buildInfoRow(
+                      LucideIcons.calendarCheck, context.l10n.end, endDate),
 
                   const SizedBox(height: 24),
-                  Text(context.l10n.description,
-                      style: TextStyle(
-                          fontWeight: FontWeight.w700,
-                          color: Colors.grey.shade800,
-                          fontSize: 16)),
+                  Text(
+                    context.l10n.description,
+                    style: TextStyle(
+                      fontWeight: FontWeight.w700,
+                      color: Colors.grey.shade800,
+                      fontSize: 16,
+                    ),
+                  ),
                   const SizedBox(height: 6),
-                  Text(description,
-                      style: TextStyle(color: Colors.grey.shade700)),
+                  Text(
+                    description,
+                    style: TextStyle(color: Colors.grey.shade700),
+                  ),
 
                   const SizedBox(height: 16),
-                  Text(context.l10n.instructions,
-                      style: TextStyle(
-                          fontWeight: FontWeight.w700,
-                          color: Colors.grey.shade800,
-                          fontSize: 16)),
+                  Text(
+                    context.l10n.instructions,
+                    style: TextStyle(
+                      fontWeight: FontWeight.w700,
+                      color: Colors.grey.shade800,
+                      fontSize: 16,
+                    ),
+                  ),
                   const SizedBox(height: 6),
-                  Text(instructions,
-                      style: TextStyle(color: Colors.grey.shade700)),
+                  Text(
+                    instructions,
+                    style: TextStyle(color: Colors.grey.shade700),
+                  ),
 
                   const SizedBox(height: 24),
                   if (_isTaken || _isSkipped)
                     Padding(
                       padding: const EdgeInsets.only(bottom: 10),
                       child: Text(
-                        _isTaken ? 'Prise déjà effectuée' : 'Prise ignorée',
+                        _isTaken
+                            ? context.l10n.intakeAlreadyTaken(medicationName)
+                            : context.l10n.intakeSkipped(medicationName),
                         style: TextStyle(
                           color: _isTaken ? Colors.green : Colors.red,
                           fontWeight: FontWeight.w600,
@@ -136,18 +149,20 @@ class MedicationDetailModal extends StatelessWidget {
                     width: double.infinity,
                     child: ElevatedButton.icon(
                       icon: const Icon(LucideIcons.check, color: Colors.white),
-                      label: const Text(
-                        'Marquer comme pris',
-                        style: TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.w600,
-                            color: Colors.white),
+                      label: Text(
+                        context.l10n.markAsTaken,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600,
+                          color: Colors.white,
+                        ),
                       ),
                       style: ElevatedButton.styleFrom(
                         backgroundColor: const Color(0xFF34C759),
                         padding: const EdgeInsets.symmetric(vertical: 16),
                         shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(12)),
+                          borderRadius: BorderRadius.circular(12),
+                        ),
                       ),
                       onPressed: () {
                         Navigator.pop(context);
@@ -157,7 +172,8 @@ class MedicationDetailModal extends StatelessWidget {
                         }
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
-                            content: Text('$medicationName marqué comme pris !'),
+                            content: Text(
+                                context.l10n.markedAsTaken(medicationName)),
                             backgroundColor: Colors.green,
                           ),
                         );
@@ -176,7 +192,8 @@ class MedicationDetailModal extends StatelessWidget {
                         }
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
-                            content: Text('$medicationName ignoré'),
+                            content: Text(
+                                context.l10n.skippedMedication(medicationName)),
                             backgroundColor: Colors.orange,
                           ),
                         );
@@ -188,7 +205,7 @@ class MedicationDetailModal extends StatelessWidget {
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                      child: const Text('Ignorer'),
+                      child: Text(context.l10n.skip),
                     ),
                   ),
                 ],
@@ -196,7 +213,7 @@ class MedicationDetailModal extends StatelessWidget {
             ),
           ),
 
-          // --- IMAGE CENTRÃ‰E SUR LA BORDURE DU HAUT ---
+          // --- Image centrée sur la bordure du haut ---
           Positioned(
             top: 0,
             left: 0,
@@ -256,6 +273,3 @@ class MedicationDetailModal extends StatelessWidget {
 //     instructions: "Take with food",
 //   ),
 // );
-
-
-

--- a/lib/widgets/pro_member.dart
+++ b/lib/widgets/pro_member.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:corevia_mobile/l10n/app_localizations.dart';
 
 class ProMemberBadge extends StatelessWidget {
   const ProMemberBadge({super.key});
@@ -21,7 +22,7 @@ class ProMemberBadge extends StatelessWidget {
           ),
           SizedBox(width: 4),
           Text(
-            'Pro member',
+            'Membre Pro',
             style: TextStyle(
               color: Colors.amber,
               fontWeight: FontWeight.w600,

--- a/lib/widgets/pro_member.dart
+++ b/lib/widgets/pro_member.dart
@@ -14,16 +14,16 @@ class ProMemberBadge extends StatelessWidget {
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
-        children: const [
-          Icon(
+        children: [
+          const Icon(
             Icons.star,
             color: Colors.amber,
             size: 16,
           ),
-          SizedBox(width: 4),
+          const SizedBox(width: 4),
           Text(
-            'Membre Pro',
-            style: TextStyle(
+            context.l10n.proMember,
+            style: const TextStyle(
               color: Colors.amber,
               fontWeight: FontWeight.w600,
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,9 +10,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   cupertino_icons: ^1.0.8
   flutter_secure_storage: ^9.0.0
-  intl: ^0.19.0
+  intl: ^0.20.2
   provider: ^6.1.1 # Pour la gestion de l'état de l'application
   go_router: ^17.0.1 # Pour la navigation
   iconsax: ^0.0.8


### PR DESCRIPTION
## What changed
- Added a lightweight fr/en localization layer with `AppLocalizations` and `context.l10n`.
- Made the app language switchable from the account/settings screen, with persistence via `SharedPreferences`.
- Localized the visible UI across the main flows: home, account, calendar, auth, chat/AI, booking, pillbox, documents, statistics, and shared widgets.
- Improved date/time formatting and typographic consistency in localized strings.
- Kept route and validator messages aligned with the selected locale.

## Why
This prepares the app for a coherent bilingual UI instead of scattered hard-coded strings.

## Notes
- The PR updates both French and English strings.
- Several review comments were addressed during the audit, including layout fixes and localization cleanup.
- Flutter tests were not fully re-run in this environment.
